### PR TITLE
Synchronize prerelease versioning between tags and package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,16 @@ jobs:
       - name: Check version in package.json matches
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
-          # Remove any prerelease or build metadata for comparison
-          BASE_VERSION=$(echo "$VERSION" | sed 's/[-+].*//')
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
-          if [ "$PACKAGE_VERSION" != "$BASE_VERSION" ]; then
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
             echo "Error: Version mismatch!"
-            echo "Tag/Input version: $BASE_VERSION"
+            echo "Tag/Input version: $VERSION"
             echo "package.json version: $PACKAGE_VERSION"
-            echo "Please update package.json to match the release version."
+            echo "Please ensure package.json includes the same version (including any prerelease/build metadata)."
             exit 1
           fi
-          echo "✓ Version in package.json matches: $BASE_VERSION"
+          echo "✓ Version in package.json matches: $PACKAGE_VERSION"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Compare the full semantic version string from the tag against `package.json` to allow prerelease identifiers in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9261065-c9b1-4907-a0d0-114168cac1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9261065-c9b1-4907-a0d0-114168cac1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

