### PR TITLE
[codex] add reusable button definitions, loading UI, and doc comments 1/4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/src/__tests__/Chat.test.tsx
+++ b/src/__tests__/Chat.test.tsx
@@ -1,71 +1,71 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { Chat } from "../components/Chat";
-import { useChatStore } from "../lib/chatStore";
-import { usePersistentButtonStore } from "../lib/persistentButtonStore";
-import type { InputMessage } from "../js/types";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Chat } from '../components/Chat';
+import { useChatStore } from '../lib/chatStore';
+import { usePersistentButtonStore } from '../lib/persistentButtonStore';
+import type { InputMessage } from '../js/types';
 
-describe("Chat Component Integration Tests", () => {
+describe('Chat Component Integration Tests', () => {
   beforeEach(() => {
     // Clear stores before each test
     useChatStore.getState().clearMessages();
     usePersistentButtonStore.getState().clearButtons();
   });
 
-  it("should render empty chat", () => {
+  it('should render empty chat', () => {
     render(<Chat />);
 
     // Should have input field
     expect(
-      screen.getByPlaceholderText("Type your message..."),
+      screen.getByPlaceholderText('Type your message...')
     ).toBeInTheDocument();
   });
 
-  it("should render with initial messages", () => {
+  it('should render with initial messages', () => {
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "other",
-        content: "Hello!",
+        type: 'other',
+        content: 'Hello!',
         timestamp: new Date(),
       },
       {
         id: 2,
-        type: "self",
-        content: "Hi there!",
+        type: 'self',
+        content: 'Hi there!',
         timestamp: new Date(),
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText("Hello!")).toBeInTheDocument();
-    expect(screen.getByText("Hi there!")).toBeInTheDocument();
+    expect(screen.getByText('Hello!')).toBeInTheDocument();
+    expect(screen.getByText('Hi there!')).toBeInTheDocument();
   });
 
-  it("should send message via ChatInput", async () => {
+  it('should send message via ChatInput', async () => {
     const user = userEvent.setup();
     render(<Chat />);
 
-    const input = screen.getByPlaceholderText("Type your message...");
-    await user.type(input, "Test message");
-    await user.keyboard("{Enter}");
+    const input = screen.getByPlaceholderText('Type your message...');
+    await user.type(input, 'Test message');
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
-      expect(screen.getByText("Test message")).toBeInTheDocument();
+      expect(screen.getByText('Test message')).toBeInTheDocument();
     });
 
     // Input should be cleared
-    expect(input).toHaveValue("");
+    expect(input).toHaveValue('');
   });
 
-  it("should apply light theme", () => {
-    const { container } = render(<Chat theme="light" />);
+  it('should apply light theme', () => {
+    const { container } = render(<Chat theme='light' />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      ".flex.flex-col",
+      '.flex.flex-col'
     ) as HTMLElement;
     // Check that theme styles are applied (without checking specific values)
     expect(chatContainer).toBeInTheDocument();
@@ -73,12 +73,12 @@ describe("Chat Component Integration Tests", () => {
     expect(chatContainer.style.color).toBeTruthy();
   });
 
-  it("should apply dark theme", () => {
-    const { container } = render(<Chat theme="dark" />);
+  it('should apply dark theme', () => {
+    const { container } = render(<Chat theme='dark' />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      ".flex.flex-col",
+      '.flex.flex-col'
     ) as HTMLElement;
     // Check that theme styles are applied (without checking specific values)
     expect(chatContainer).toBeInTheDocument();
@@ -86,18 +86,18 @@ describe("Chat Component Integration Tests", () => {
     expect(chatContainer.style.color).toBeTruthy();
   });
 
-  it("should apply custom theme", () => {
+  it('should apply custom theme', () => {
     const customTheme = {
-      backgroundColor: "#ff0000",
-      textColor: "#00ff00",
-      primaryColor: "#0000ff",
+      backgroundColor: '#ff0000',
+      textColor: '#00ff00',
+      primaryColor: '#0000ff',
     };
 
     const { container } = render(<Chat theme={customTheme} />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      ".flex.flex-col",
+      '.flex.flex-col'
     ) as HTMLElement;
     expect(chatContainer).toHaveStyle({
       backgroundColor: customTheme.backgroundColor,
@@ -105,15 +105,15 @@ describe("Chat Component Integration Tests", () => {
     });
   });
 
-  it("should trigger userResponseCallback when user replies", async () => {
+  it('should trigger userResponseCallback when user replies', async () => {
     const user = userEvent.setup();
     const callback = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "other",
-        content: "Please respond",
+        type: 'other',
+        content: 'Please respond',
         timestamp: new Date(),
         userResponseCallback: callback,
       },
@@ -121,24 +121,24 @@ describe("Chat Component Integration Tests", () => {
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const input = screen.getByPlaceholderText("Type your message...");
-    await user.type(input, "My response");
-    await user.keyboard("{Enter}");
+    const input = screen.getByPlaceholderText('Type your message...');
+    await user.type(input, 'My response');
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("should not trigger callback on self message", async () => {
+  it('should not trigger callback on self message', async () => {
     const user = userEvent.setup();
     const callback = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "self",
-        content: "My message",
+        type: 'self',
+        content: 'My message',
         timestamp: new Date(),
         userResponseCallback: callback,
       },
@@ -146,126 +146,126 @@ describe("Chat Component Integration Tests", () => {
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const input = screen.getByPlaceholderText("Type your message...");
-    await user.type(input, "Another message");
-    await user.keyboard("{Enter}");
+    const input = screen.getByPlaceholderText('Type your message...');
+    await user.type(input, 'Another message');
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
-      expect(screen.getByText("Another message")).toBeInTheDocument();
+      expect(screen.getByText('Another message')).toBeInTheDocument();
     });
 
     // Callback should not be called for self messages
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it("should display message buttons", () => {
+  it('should display message buttons', () => {
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "other",
-        content: "Choose an option",
+        type: 'other',
+        content: 'Choose an option',
         timestamp: new Date(),
         buttons: [
-          { label: "Option 1", onClick: () => {} },
-          { label: "Option 2", onClick: () => {} },
+          { label: 'Option 1', onClick: () => {} },
+          { label: 'Option 2', onClick: () => {} },
         ],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText("Option 1")).toBeInTheDocument();
-    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
   });
 
-  it("should display a loading indicator from the chat store", () => {
-    useChatStore.getState().setLoading(true, "Looking up recommendations...");
+  it('should display a loading indicator from the chat store', () => {
+    useChatStore.getState().setLoading(true, 'Looking up recommendations...');
 
     render(<Chat />);
 
     expect(
-      screen.getByRole("status", {
-        name: "Looking up recommendations...",
-      }),
+      screen.getByRole('status', {
+        name: 'Looking up recommendations...',
+      })
     ).toBeInTheDocument();
   });
 
-  it("should render a loading assistant message in the message list", () => {
+  it('should render a loading assistant message in the message list', () => {
     render(
       <Chat
         initialMessages={[
           {
-            type: "other",
-            content: "",
+            type: 'other',
+            content: '',
             isLoading: true,
-            loadingLabel: "Looking up recommendations...",
+            loadingLabel: 'Looking up recommendations...',
           },
         ]}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("status", {
-        name: "Looking up recommendations...",
-      }),
+      screen.getByRole('status', {
+        name: 'Looking up recommendations...',
+      })
     ).toBeInTheDocument();
   });
 
-  it("should handle button clicks", async () => {
+  it('should handle button clicks', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "other",
-        content: "Click the button",
+        type: 'other',
+        content: 'Click the button',
         timestamp: new Date(),
-        buttons: [{ label: "Click Me", onClick }],
+        buttons: [{ label: 'Click Me', onClick }],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const button = screen.getByText("Click Me");
+    const button = screen.getByText('Click Me');
     await user.click(button);
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it("should clear previous message buttons when new message is sent", async () => {
+  it('should clear previous message buttons when new message is sent', async () => {
     const user = userEvent.setup();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: "other",
-        content: "Message with buttons",
+        type: 'other',
+        content: 'Message with buttons',
         timestamp: new Date(),
-        buttons: [{ label: "Button 1" }],
+        buttons: [{ label: 'Button 1' }],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText("Button 1")).toBeInTheDocument();
+    expect(screen.getByText('Button 1')).toBeInTheDocument();
 
-    const input = screen.getByPlaceholderText("Type your message...");
-    await user.type(input, "New message");
-    await user.keyboard("{Enter}");
+    const input = screen.getByPlaceholderText('Type your message...');
+    await user.type(input, 'New message');
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
-      expect(screen.queryByText("Button 1")).not.toBeInTheDocument();
+      expect(screen.queryByText('Button 1')).not.toBeInTheDocument();
     });
   });
 
-  it("should not send empty messages", async () => {
+  it('should not send empty messages', async () => {
     const user = userEvent.setup();
     render(<Chat />);
 
-    const input = screen.getByPlaceholderText("Type your message...");
-    await user.type(input, "   ");
-    await user.keyboard("{Enter}");
+    const input = screen.getByPlaceholderText('Type your message...');
+    await user.type(input, '   ');
+    await user.keyboard('{Enter}');
 
     // No message should be added
     const messages = useChatStore.getState().getMessages();

--- a/src/__tests__/Chat.test.tsx
+++ b/src/__tests__/Chat.test.tsx
@@ -179,15 +179,11 @@ describe('Chat Component Integration Tests', () => {
   });
 
   it('should display a loading indicator from the chat store', () => {
-    useChatStore.getState().setLoading(true, 'Looking up recommendations...');
+    useChatStore.getState().setLoading(true);
 
     render(<Chat />);
 
-    expect(
-      screen.getByRole('status', {
-        name: 'Looking up recommendations...',
-      })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
   it('should render a loading assistant message in the message list', () => {
@@ -198,17 +194,12 @@ describe('Chat Component Integration Tests', () => {
             type: 'other',
             content: '',
             isLoading: true,
-            loadingLabel: 'Looking up recommendations...',
           },
         ]}
       />
     );
 
-    expect(
-      screen.getByRole('status', {
-        name: 'Looking up recommendations...',
-      })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
   it('should handle button clicks', async () => {

--- a/src/__tests__/Chat.test.tsx
+++ b/src/__tests__/Chat.test.tsx
@@ -1,71 +1,71 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { Chat } from '../components/Chat';
-import { useChatStore } from '../lib/chatStore';
-import { usePersistentButtonStore } from '../lib/persistentButtonStore';
-import type { InputMessage } from '../js/types';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Chat } from "../components/Chat";
+import { useChatStore } from "../lib/chatStore";
+import { usePersistentButtonStore } from "../lib/persistentButtonStore";
+import type { InputMessage } from "../js/types";
 
-describe('Chat Component Integration Tests', () => {
+describe("Chat Component Integration Tests", () => {
   beforeEach(() => {
     // Clear stores before each test
     useChatStore.getState().clearMessages();
     usePersistentButtonStore.getState().clearButtons();
   });
 
-  it('should render empty chat', () => {
+  it("should render empty chat", () => {
     render(<Chat />);
 
     // Should have input field
     expect(
-      screen.getByPlaceholderText('Type your message...')
+      screen.getByPlaceholderText("Type your message..."),
     ).toBeInTheDocument();
   });
 
-  it('should render with initial messages', () => {
+  it("should render with initial messages", () => {
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'other',
-        content: 'Hello!',
+        type: "other",
+        content: "Hello!",
         timestamp: new Date(),
       },
       {
         id: 2,
-        type: 'self',
-        content: 'Hi there!',
+        type: "self",
+        content: "Hi there!",
         timestamp: new Date(),
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText('Hello!')).toBeInTheDocument();
-    expect(screen.getByText('Hi there!')).toBeInTheDocument();
+    expect(screen.getByText("Hello!")).toBeInTheDocument();
+    expect(screen.getByText("Hi there!")).toBeInTheDocument();
   });
 
-  it('should send message via ChatInput', async () => {
+  it("should send message via ChatInput", async () => {
     const user = userEvent.setup();
     render(<Chat />);
 
-    const input = screen.getByPlaceholderText('Type your message...');
-    await user.type(input, 'Test message');
-    await user.keyboard('{Enter}');
+    const input = screen.getByPlaceholderText("Type your message...");
+    await user.type(input, "Test message");
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByText('Test message')).toBeInTheDocument();
+      expect(screen.getByText("Test message")).toBeInTheDocument();
     });
 
     // Input should be cleared
-    expect(input).toHaveValue('');
+    expect(input).toHaveValue("");
   });
 
-  it('should apply light theme', () => {
-    const { container } = render(<Chat theme='light' />);
+  it("should apply light theme", () => {
+    const { container } = render(<Chat theme="light" />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      '.flex.flex-col'
+      ".flex.flex-col",
     ) as HTMLElement;
     // Check that theme styles are applied (without checking specific values)
     expect(chatContainer).toBeInTheDocument();
@@ -73,12 +73,12 @@ describe('Chat Component Integration Tests', () => {
     expect(chatContainer.style.color).toBeTruthy();
   });
 
-  it('should apply dark theme', () => {
-    const { container } = render(<Chat theme='dark' />);
+  it("should apply dark theme", () => {
+    const { container } = render(<Chat theme="dark" />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      '.flex.flex-col'
+      ".flex.flex-col",
     ) as HTMLElement;
     // Check that theme styles are applied (without checking specific values)
     expect(chatContainer).toBeInTheDocument();
@@ -86,18 +86,18 @@ describe('Chat Component Integration Tests', () => {
     expect(chatContainer.style.color).toBeTruthy();
   });
 
-  it('should apply custom theme', () => {
+  it("should apply custom theme", () => {
     const customTheme = {
-      backgroundColor: '#ff0000',
-      textColor: '#00ff00',
-      primaryColor: '#0000ff',
+      backgroundColor: "#ff0000",
+      textColor: "#00ff00",
+      primaryColor: "#0000ff",
     };
 
     const { container } = render(<Chat theme={customTheme} />);
 
     // The styles are applied to the inner div, not the wrapper
     const chatContainer = container.querySelector(
-      '.flex.flex-col'
+      ".flex.flex-col",
     ) as HTMLElement;
     expect(chatContainer).toHaveStyle({
       backgroundColor: customTheme.backgroundColor,
@@ -105,15 +105,15 @@ describe('Chat Component Integration Tests', () => {
     });
   });
 
-  it('should trigger userResponseCallback when user replies', async () => {
+  it("should trigger userResponseCallback when user replies", async () => {
     const user = userEvent.setup();
     const callback = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'other',
-        content: 'Please respond',
+        type: "other",
+        content: "Please respond",
         timestamp: new Date(),
         userResponseCallback: callback,
       },
@@ -121,24 +121,24 @@ describe('Chat Component Integration Tests', () => {
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const input = screen.getByPlaceholderText('Type your message...');
-    await user.type(input, 'My response');
-    await user.keyboard('{Enter}');
+    const input = screen.getByPlaceholderText("Type your message...");
+    await user.type(input, "My response");
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('should not trigger callback on self message', async () => {
+  it("should not trigger callback on self message", async () => {
     const user = userEvent.setup();
     const callback = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'self',
-        content: 'My message',
+        type: "self",
+        content: "My message",
         timestamp: new Date(),
         userResponseCallback: callback,
       },
@@ -146,93 +146,126 @@ describe('Chat Component Integration Tests', () => {
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const input = screen.getByPlaceholderText('Type your message...');
-    await user.type(input, 'Another message');
-    await user.keyboard('{Enter}');
+    const input = screen.getByPlaceholderText("Type your message...");
+    await user.type(input, "Another message");
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByText('Another message')).toBeInTheDocument();
+      expect(screen.getByText("Another message")).toBeInTheDocument();
     });
 
     // Callback should not be called for self messages
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('should display message buttons', () => {
+  it("should display message buttons", () => {
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'other',
-        content: 'Choose an option',
+        type: "other",
+        content: "Choose an option",
         timestamp: new Date(),
         buttons: [
-          { label: 'Option 1', onClick: () => {} },
-          { label: 'Option 2', onClick: () => {} },
+          { label: "Option 1", onClick: () => {} },
+          { label: "Option 2", onClick: () => {} },
         ],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText('Option 1')).toBeInTheDocument();
-    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
   });
 
-  it('should handle button clicks', async () => {
+  it("should display a loading indicator from the chat store", () => {
+    useChatStore.getState().setLoading(true, "Looking up recommendations...");
+
+    render(<Chat />);
+
+    expect(
+      screen.getByRole("status", {
+        name: "Looking up recommendations...",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a loading assistant message in the message list", () => {
+    render(
+      <Chat
+        initialMessages={[
+          {
+            type: "other",
+            content: "",
+            isLoading: true,
+            loadingLabel: "Looking up recommendations...",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("status", {
+        name: "Looking up recommendations...",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("should handle button clicks", async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'other',
-        content: 'Click the button',
+        type: "other",
+        content: "Click the button",
         timestamp: new Date(),
-        buttons: [{ label: 'Click Me', onClick }],
+        buttons: [{ label: "Click Me", onClick }],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    const button = screen.getByText('Click Me');
+    const button = screen.getByText("Click Me");
     await user.click(button);
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should clear previous message buttons when new message is sent', async () => {
+  it("should clear previous message buttons when new message is sent", async () => {
     const user = userEvent.setup();
 
     const initialMessages: InputMessage[] = [
       {
         id: 1,
-        type: 'other',
-        content: 'Message with buttons',
+        type: "other",
+        content: "Message with buttons",
         timestamp: new Date(),
-        buttons: [{ label: 'Button 1' }],
+        buttons: [{ label: "Button 1" }],
       },
     ];
 
     render(<Chat initialMessages={initialMessages} />);
 
-    expect(screen.getByText('Button 1')).toBeInTheDocument();
+    expect(screen.getByText("Button 1")).toBeInTheDocument();
 
-    const input = screen.getByPlaceholderText('Type your message...');
-    await user.type(input, 'New message');
-    await user.keyboard('{Enter}');
+    const input = screen.getByPlaceholderText("Type your message...");
+    await user.type(input, "New message");
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.queryByText('Button 1')).not.toBeInTheDocument();
+      expect(screen.queryByText("Button 1")).not.toBeInTheDocument();
     });
   });
 
-  it('should not send empty messages', async () => {
+  it("should not send empty messages", async () => {
     const user = userEvent.setup();
     render(<Chat />);
 
-    const input = screen.getByPlaceholderText('Type your message...');
-    await user.type(input, '   ');
-    await user.keyboard('{Enter}');
+    const input = screen.getByPlaceholderText("Type your message...");
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
 
     // No message should be added
     const messages = useChatStore.getState().getMessages();

--- a/src/__tests__/chatStore.test.ts
+++ b/src/__tests__/chatStore.test.ts
@@ -219,11 +219,10 @@ describe('Chat Store Unit Tests', () => {
     it('should clear loading state', () => {
       const store = useChatStore.getState();
 
-      store.setLoading(true, 'Thinking...');
+      store.setLoading(true);
       store.clearMessages();
 
       expect(useChatStore.getState().isLoading).toBe(false);
-      expect(useChatStore.getState().loadingMessage).toBeUndefined();
     });
   });
 
@@ -231,17 +230,13 @@ describe('Chat Store Unit Tests', () => {
     it('should set and clear loading state', () => {
       const store = useChatStore.getState();
 
-      store.setLoading(true, 'Looking up options...');
+      store.setLoading(true);
 
       expect(useChatStore.getState().isLoading).toBe(true);
-      expect(useChatStore.getState().loadingMessage).toBe(
-        'Looking up options...'
-      );
 
       store.clearLoading();
 
       expect(useChatStore.getState().isLoading).toBe(false);
-      expect(useChatStore.getState().loadingMessage).toBeUndefined();
     });
   });
 

--- a/src/__tests__/chatStore.test.ts
+++ b/src/__tests__/chatStore.test.ts
@@ -1,40 +1,40 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useChatStore } from "../lib/chatStore";
-import { usePersistentButtonStore } from "../lib/persistentButtonStore";
-import type { InputMessage, Message } from "../js/types";
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useChatStore } from '../lib/chatStore';
+import { usePersistentButtonStore } from '../lib/persistentButtonStore';
+import type { InputMessage, Message } from '../js/types';
 
-describe("Chat Store Unit Tests", () => {
+describe('Chat Store Unit Tests', () => {
   beforeEach(() => {
     // Clear store before each test
     useChatStore.getState().clearMessages();
     usePersistentButtonStore.getState().clearButtons();
   });
 
-  describe("addMessage", () => {
-    it("should add message with id and timestamp", () => {
+  describe('addMessage', () => {
+    it('should add message with id and timestamp', () => {
       const store = useChatStore.getState();
 
       store.addMessage({
-        type: "self",
-        content: "Hello",
+        type: 'self',
+        content: 'Hello',
       });
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(1);
       expect(messages[0]).toMatchObject({
         id: 1,
-        type: "self",
-        content: "Hello",
+        type: 'self',
+        content: 'Hello',
       });
       expect(messages[0]?.timestamp).toBeInstanceOf(Date);
     });
 
-    it("should increment id for each message", () => {
+    it('should increment id for each message', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "First" });
-      store.addMessage({ type: "other", content: "Second" });
-      store.addMessage({ type: "self", content: "Third" });
+      store.addMessage({ type: 'self', content: 'First' });
+      store.addMessage({ type: 'other', content: 'Second' });
+      store.addMessage({ type: 'self', content: 'Third' });
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(3);
@@ -43,20 +43,20 @@ describe("Chat Store Unit Tests", () => {
       expect(messages[2]?.id).toBe(3);
     });
 
-    it("should clear buttons from previous messages when adding new message", () => {
+    it('should clear buttons from previous messages when adding new message', () => {
       const store = useChatStore.getState();
 
       store.addMessage({
-        type: "other",
-        content: "First message",
-        buttons: [{ label: "Button 1" }],
+        type: 'other',
+        content: 'First message',
+        buttons: [{ label: 'Button 1' }],
       });
 
       expect(store.getMessages()[0]?.buttons).toHaveLength(1);
 
       store.addMessage({
-        type: "self",
-        content: "Second message",
+        type: 'self',
+        content: 'Second message',
       });
 
       const messages = store.getMessages();
@@ -65,11 +65,11 @@ describe("Chat Store Unit Tests", () => {
       expect(messages[1]?.buttons).toBeUndefined();
     });
 
-    it("should remove abort button from persistent buttons", () => {
+    it('should remove abort button from persistent buttons', () => {
       const persistentStore = usePersistentButtonStore.getState();
       persistentStore.addButton({
-        id: "input-request-abort",
-        label: "Abort",
+        id: 'input-request-abort',
+        label: 'Abort',
         onClick: () => {},
       });
 
@@ -77,29 +77,29 @@ describe("Chat Store Unit Tests", () => {
 
       const chatStore = useChatStore.getState();
       chatStore.addMessage({
-        type: "self",
-        content: "New message",
+        type: 'self',
+        content: 'New message',
       });
 
       expect(persistentStore.getButtons()).toHaveLength(0);
     });
   });
 
-  describe("addMessages", () => {
-    it("should add multiple messages at once", () => {
+  describe('addMessages', () => {
+    it('should add multiple messages at once', () => {
       const store = useChatStore.getState();
 
       const messages: InputMessage[] = [
         {
           id: 1,
-          type: "other",
-          content: "First",
+          type: 'other',
+          content: 'First',
           timestamp: new Date(),
         },
         {
           id: 2,
-          type: "self",
-          content: "Second",
+          type: 'self',
+          content: 'Second',
           timestamp: new Date(),
         },
       ];
@@ -107,20 +107,20 @@ describe("Chat Store Unit Tests", () => {
       store.addMessages(messages);
 
       expect(store.getMessages()).toHaveLength(2);
-      expect(store.getMessages()[0]?.content).toBe("First");
-      expect(store.getMessages()[1]?.content).toBe("Second");
+      expect(store.getMessages()[0]?.content).toBe('First');
+      expect(store.getMessages()[1]?.content).toBe('Second');
     });
 
-    it("should append to existing messages", () => {
+    it('should append to existing messages', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "Existing" });
+      store.addMessage({ type: 'self', content: 'Existing' });
 
       const newMessages: InputMessage[] = [
         {
           id: 2,
-          type: "other",
-          content: "New",
+          type: 'other',
+          content: 'New',
           timestamp: new Date(),
         },
       ];
@@ -131,21 +131,21 @@ describe("Chat Store Unit Tests", () => {
     });
   });
 
-  describe("setMessages", () => {
-    it("should replace all messages", () => {
+  describe('setMessages', () => {
+    it('should replace all messages', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "First" });
-      store.addMessage({ type: "other", content: "Second" });
+      store.addMessage({ type: 'self', content: 'First' });
+      store.addMessage({ type: 'other', content: 'Second' });
 
       expect(store.getMessages()).toHaveLength(2);
 
       const newMessages: Message[] = [
         {
           id: 10,
-          rawContent: "Replaced",
-          type: "other",
-          content: "Replaced",
+          rawContent: 'Replaced',
+          type: 'other',
+          content: 'Replaced',
           timestamp: new Date(),
         },
       ];
@@ -154,60 +154,60 @@ describe("Chat Store Unit Tests", () => {
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(1);
-      expect(messages[0]?.content).toBe("Replaced");
+      expect(messages[0]?.content).toBe('Replaced');
       expect(messages[0]?.id).toBe(10);
     });
 
-    it("should handle empty array", () => {
+    it('should handle empty array', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "Test" });
+      store.addMessage({ type: 'self', content: 'Test' });
       store.setMessages([]);
 
       expect(store.getMessages()).toHaveLength(0);
     });
   });
 
-  describe("getMessages", () => {
-    it("should return current messages", () => {
+  describe('getMessages', () => {
+    it('should return current messages', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "Test" });
+      store.addMessage({ type: 'self', content: 'Test' });
       const messages = store.getMessages();
 
       expect(messages).toHaveLength(1);
-      expect(messages[0]?.content).toBe("Test");
+      expect(messages[0]?.content).toBe('Test');
     });
 
-    it("should return empty array when no messages", () => {
+    it('should return empty array when no messages', () => {
       const store = useChatStore.getState();
       expect(store.getMessages()).toEqual([]);
     });
   });
 
-  describe("getPreviousMessage", () => {
-    it("should return last message", () => {
+  describe('getPreviousMessage', () => {
+    it('should return last message', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "First" });
-      store.addMessage({ type: "other", content: "Last" });
+      store.addMessage({ type: 'self', content: 'First' });
+      store.addMessage({ type: 'other', content: 'Last' });
 
       const previousMessage = store.getPreviousMessage();
-      expect(previousMessage?.content).toBe("Last");
+      expect(previousMessage?.content).toBe('Last');
     });
 
-    it("should return undefined when no messages", () => {
+    it('should return undefined when no messages', () => {
       const store = useChatStore.getState();
       expect(store.getPreviousMessage()).toBeUndefined();
     });
   });
 
-  describe("clearMessages", () => {
-    it("should remove all messages", () => {
+  describe('clearMessages', () => {
+    it('should remove all messages', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "First" });
-      store.addMessage({ type: "other", content: "Second" });
+      store.addMessage({ type: 'self', content: 'First' });
+      store.addMessage({ type: 'other', content: 'Second' });
 
       expect(store.getMessages()).toHaveLength(2);
 
@@ -216,10 +216,10 @@ describe("Chat Store Unit Tests", () => {
       expect(store.getMessages()).toEqual([]);
     });
 
-    it("should clear loading state", () => {
+    it('should clear loading state', () => {
       const store = useChatStore.getState();
 
-      store.setLoading(true, "Thinking...");
+      store.setLoading(true, 'Thinking...');
       store.clearMessages();
 
       expect(useChatStore.getState().isLoading).toBe(false);
@@ -227,15 +227,15 @@ describe("Chat Store Unit Tests", () => {
     });
   });
 
-  describe("loading state", () => {
-    it("should set and clear loading state", () => {
+  describe('loading state', () => {
+    it('should set and clear loading state', () => {
       const store = useChatStore.getState();
 
-      store.setLoading(true, "Looking up options...");
+      store.setLoading(true, 'Looking up options...');
 
       expect(useChatStore.getState().isLoading).toBe(true);
       expect(useChatStore.getState().loadingMessage).toBe(
-        "Looking up options...",
+        'Looking up options...'
       );
 
       store.clearLoading();
@@ -245,26 +245,26 @@ describe("Chat Store Unit Tests", () => {
     });
   });
 
-  describe("clearButtons", () => {
-    it("should remove buttons from all messages", () => {
+  describe('clearButtons', () => {
+    it('should remove buttons from all messages', () => {
       const store = useChatStore.getState();
 
       store.setMessages([
         {
           id: 1,
-          type: "other",
-          content: "First",
-          rawContent: "First",
+          type: 'other',
+          content: 'First',
+          rawContent: 'First',
           timestamp: new Date(),
-          buttons: [{ label: "Button 1" }],
+          buttons: [{ label: 'Button 1' }],
         },
         {
           id: 2,
-          type: "other",
-          content: "Second",
-          rawContent: "Second",
+          type: 'other',
+          content: 'Second',
+          rawContent: 'Second',
           timestamp: new Date(),
-          buttons: [{ label: "Button 2" }],
+          buttons: [{ label: 'Button 2' }],
         },
       ]);
 
@@ -275,36 +275,36 @@ describe("Chat Store Unit Tests", () => {
       expect(messages[1]?.buttons).toEqual([]);
     });
 
-    it("should work with messages that have no buttons", () => {
+    it('should work with messages that have no buttons', () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: "self", content: "No buttons" });
+      store.addMessage({ type: 'self', content: 'No buttons' });
       store.clearButtons();
 
       expect(store.getMessages()[0]?.buttons).toEqual([]);
     });
   });
 
-  describe("clearPreviousMessageButtons", () => {
-    it("should remove buttons from last message only", () => {
+  describe('clearPreviousMessageButtons', () => {
+    it('should remove buttons from last message only', () => {
       const store = useChatStore.getState();
 
       store.setMessages([
         {
           id: 1,
-          type: "other",
-          content: "First",
-          rawContent: "First",
+          type: 'other',
+          content: 'First',
+          rawContent: 'First',
           timestamp: new Date(),
-          buttons: [{ label: "Button 1" }],
+          buttons: [{ label: 'Button 1' }],
         },
         {
           id: 2,
-          type: "other",
-          content: "Second",
-          rawContent: "Second",
+          type: 'other',
+          content: 'Second',
+          rawContent: 'Second',
           timestamp: new Date(),
-          buttons: [{ label: "Button 2" }],
+          buttons: [{ label: 'Button 2' }],
         },
       ]);
 
@@ -315,23 +315,23 @@ describe("Chat Store Unit Tests", () => {
       expect(messages[1]?.buttons).toEqual([]);
     });
 
-    it("should do nothing when no messages", () => {
+    it('should do nothing when no messages', () => {
       const store = useChatStore.getState();
       expect(() => store.clearPreviousMessageButtons()).not.toThrow();
     });
   });
 
-  describe("clearPreviousMessageCallback", () => {
-    it("should remove callback from last message", () => {
+  describe('clearPreviousMessageCallback', () => {
+    it('should remove callback from last message', () => {
       const store = useChatStore.getState();
       const callback = vi.fn();
 
       store.setMessages([
         {
           id: 1,
-          type: "other",
-          content: "Message",
-          rawContent: "Message",
+          type: 'other',
+          content: 'Message',
+          rawContent: 'Message',
           timestamp: new Date(),
           userResponseCallback: callback,
         },
@@ -344,7 +344,7 @@ describe("Chat Store Unit Tests", () => {
       expect(store.getPreviousMessage()?.userResponseCallback).toBeUndefined();
     });
 
-    it("should only remove callback from last message", () => {
+    it('should only remove callback from last message', () => {
       const store = useChatStore.getState();
       const callback1 = vi.fn();
       const callback2 = vi.fn();
@@ -352,17 +352,17 @@ describe("Chat Store Unit Tests", () => {
       store.setMessages([
         {
           id: 1,
-          type: "other",
-          content: "First",
-          rawContent: "First",
+          type: 'other',
+          content: 'First',
+          rawContent: 'First',
           timestamp: new Date(),
           userResponseCallback: callback1,
         },
         {
           id: 2,
-          type: "other",
-          content: "Second",
-          rawContent: "Second",
+          type: 'other',
+          content: 'Second',
+          rawContent: 'Second',
           timestamp: new Date(),
           userResponseCallback: callback2,
         },
@@ -375,7 +375,7 @@ describe("Chat Store Unit Tests", () => {
       expect(messages[1]?.userResponseCallback).toBeUndefined();
     });
 
-    it("should do nothing when no messages", () => {
+    it('should do nothing when no messages', () => {
       const store = useChatStore.getState();
       expect(() => store.clearPreviousMessageCallback()).not.toThrow();
     });

--- a/src/__tests__/chatStore.test.ts
+++ b/src/__tests__/chatStore.test.ts
@@ -1,40 +1,40 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useChatStore } from '../lib/chatStore';
-import { usePersistentButtonStore } from '../lib/persistentButtonStore';
-import type { InputMessage, Message } from '../js/types';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useChatStore } from "../lib/chatStore";
+import { usePersistentButtonStore } from "../lib/persistentButtonStore";
+import type { InputMessage, Message } from "../js/types";
 
-describe('Chat Store Unit Tests', () => {
+describe("Chat Store Unit Tests", () => {
   beforeEach(() => {
     // Clear store before each test
     useChatStore.getState().clearMessages();
     usePersistentButtonStore.getState().clearButtons();
   });
 
-  describe('addMessage', () => {
-    it('should add message with id and timestamp', () => {
+  describe("addMessage", () => {
+    it("should add message with id and timestamp", () => {
       const store = useChatStore.getState();
 
       store.addMessage({
-        type: 'self',
-        content: 'Hello',
+        type: "self",
+        content: "Hello",
       });
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(1);
       expect(messages[0]).toMatchObject({
         id: 1,
-        type: 'self',
-        content: 'Hello',
+        type: "self",
+        content: "Hello",
       });
       expect(messages[0]?.timestamp).toBeInstanceOf(Date);
     });
 
-    it('should increment id for each message', () => {
+    it("should increment id for each message", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'First' });
-      store.addMessage({ type: 'other', content: 'Second' });
-      store.addMessage({ type: 'self', content: 'Third' });
+      store.addMessage({ type: "self", content: "First" });
+      store.addMessage({ type: "other", content: "Second" });
+      store.addMessage({ type: "self", content: "Third" });
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(3);
@@ -43,20 +43,20 @@ describe('Chat Store Unit Tests', () => {
       expect(messages[2]?.id).toBe(3);
     });
 
-    it('should clear buttons from previous messages when adding new message', () => {
+    it("should clear buttons from previous messages when adding new message", () => {
       const store = useChatStore.getState();
 
       store.addMessage({
-        type: 'other',
-        content: 'First message',
-        buttons: [{ label: 'Button 1' }],
+        type: "other",
+        content: "First message",
+        buttons: [{ label: "Button 1" }],
       });
 
       expect(store.getMessages()[0]?.buttons).toHaveLength(1);
 
       store.addMessage({
-        type: 'self',
-        content: 'Second message',
+        type: "self",
+        content: "Second message",
       });
 
       const messages = store.getMessages();
@@ -65,11 +65,11 @@ describe('Chat Store Unit Tests', () => {
       expect(messages[1]?.buttons).toBeUndefined();
     });
 
-    it('should remove abort button from persistent buttons', () => {
+    it("should remove abort button from persistent buttons", () => {
       const persistentStore = usePersistentButtonStore.getState();
       persistentStore.addButton({
-        id: 'input-request-abort',
-        label: 'Abort',
+        id: "input-request-abort",
+        label: "Abort",
         onClick: () => {},
       });
 
@@ -77,29 +77,29 @@ describe('Chat Store Unit Tests', () => {
 
       const chatStore = useChatStore.getState();
       chatStore.addMessage({
-        type: 'self',
-        content: 'New message',
+        type: "self",
+        content: "New message",
       });
 
       expect(persistentStore.getButtons()).toHaveLength(0);
     });
   });
 
-  describe('addMessages', () => {
-    it('should add multiple messages at once', () => {
+  describe("addMessages", () => {
+    it("should add multiple messages at once", () => {
       const store = useChatStore.getState();
 
       const messages: InputMessage[] = [
         {
           id: 1,
-          type: 'other',
-          content: 'First',
+          type: "other",
+          content: "First",
           timestamp: new Date(),
         },
         {
           id: 2,
-          type: 'self',
-          content: 'Second',
+          type: "self",
+          content: "Second",
           timestamp: new Date(),
         },
       ];
@@ -107,20 +107,20 @@ describe('Chat Store Unit Tests', () => {
       store.addMessages(messages);
 
       expect(store.getMessages()).toHaveLength(2);
-      expect(store.getMessages()[0]?.content).toBe('First');
-      expect(store.getMessages()[1]?.content).toBe('Second');
+      expect(store.getMessages()[0]?.content).toBe("First");
+      expect(store.getMessages()[1]?.content).toBe("Second");
     });
 
-    it('should append to existing messages', () => {
+    it("should append to existing messages", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'Existing' });
+      store.addMessage({ type: "self", content: "Existing" });
 
       const newMessages: InputMessage[] = [
         {
           id: 2,
-          type: 'other',
-          content: 'New',
+          type: "other",
+          content: "New",
           timestamp: new Date(),
         },
       ];
@@ -131,21 +131,21 @@ describe('Chat Store Unit Tests', () => {
     });
   });
 
-  describe('setMessages', () => {
-    it('should replace all messages', () => {
+  describe("setMessages", () => {
+    it("should replace all messages", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'First' });
-      store.addMessage({ type: 'other', content: 'Second' });
+      store.addMessage({ type: "self", content: "First" });
+      store.addMessage({ type: "other", content: "Second" });
 
       expect(store.getMessages()).toHaveLength(2);
 
       const newMessages: Message[] = [
         {
           id: 10,
-          rawContent: 'Replaced',
-          type: 'other',
-          content: 'Replaced',
+          rawContent: "Replaced",
+          type: "other",
+          content: "Replaced",
           timestamp: new Date(),
         },
       ];
@@ -154,60 +154,60 @@ describe('Chat Store Unit Tests', () => {
 
       const messages = store.getMessages();
       expect(messages).toHaveLength(1);
-      expect(messages[0]?.content).toBe('Replaced');
+      expect(messages[0]?.content).toBe("Replaced");
       expect(messages[0]?.id).toBe(10);
     });
 
-    it('should handle empty array', () => {
+    it("should handle empty array", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'Test' });
+      store.addMessage({ type: "self", content: "Test" });
       store.setMessages([]);
 
       expect(store.getMessages()).toHaveLength(0);
     });
   });
 
-  describe('getMessages', () => {
-    it('should return current messages', () => {
+  describe("getMessages", () => {
+    it("should return current messages", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'Test' });
+      store.addMessage({ type: "self", content: "Test" });
       const messages = store.getMessages();
 
       expect(messages).toHaveLength(1);
-      expect(messages[0]?.content).toBe('Test');
+      expect(messages[0]?.content).toBe("Test");
     });
 
-    it('should return empty array when no messages', () => {
+    it("should return empty array when no messages", () => {
       const store = useChatStore.getState();
       expect(store.getMessages()).toEqual([]);
     });
   });
 
-  describe('getPreviousMessage', () => {
-    it('should return last message', () => {
+  describe("getPreviousMessage", () => {
+    it("should return last message", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'First' });
-      store.addMessage({ type: 'other', content: 'Last' });
+      store.addMessage({ type: "self", content: "First" });
+      store.addMessage({ type: "other", content: "Last" });
 
       const previousMessage = store.getPreviousMessage();
-      expect(previousMessage?.content).toBe('Last');
+      expect(previousMessage?.content).toBe("Last");
     });
 
-    it('should return undefined when no messages', () => {
+    it("should return undefined when no messages", () => {
       const store = useChatStore.getState();
       expect(store.getPreviousMessage()).toBeUndefined();
     });
   });
 
-  describe('clearMessages', () => {
-    it('should remove all messages', () => {
+  describe("clearMessages", () => {
+    it("should remove all messages", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'First' });
-      store.addMessage({ type: 'other', content: 'Second' });
+      store.addMessage({ type: "self", content: "First" });
+      store.addMessage({ type: "other", content: "Second" });
 
       expect(store.getMessages()).toHaveLength(2);
 
@@ -215,28 +215,56 @@ describe('Chat Store Unit Tests', () => {
 
       expect(store.getMessages()).toEqual([]);
     });
+
+    it("should clear loading state", () => {
+      const store = useChatStore.getState();
+
+      store.setLoading(true, "Thinking...");
+      store.clearMessages();
+
+      expect(useChatStore.getState().isLoading).toBe(false);
+      expect(useChatStore.getState().loadingMessage).toBeUndefined();
+    });
   });
 
-  describe('clearButtons', () => {
-    it('should remove buttons from all messages', () => {
+  describe("loading state", () => {
+    it("should set and clear loading state", () => {
+      const store = useChatStore.getState();
+
+      store.setLoading(true, "Looking up options...");
+
+      expect(useChatStore.getState().isLoading).toBe(true);
+      expect(useChatStore.getState().loadingMessage).toBe(
+        "Looking up options...",
+      );
+
+      store.clearLoading();
+
+      expect(useChatStore.getState().isLoading).toBe(false);
+      expect(useChatStore.getState().loadingMessage).toBeUndefined();
+    });
+  });
+
+  describe("clearButtons", () => {
+    it("should remove buttons from all messages", () => {
       const store = useChatStore.getState();
 
       store.setMessages([
         {
           id: 1,
-          type: 'other',
-          content: 'First',
-          rawContent: 'First',
+          type: "other",
+          content: "First",
+          rawContent: "First",
           timestamp: new Date(),
-          buttons: [{ label: 'Button 1' }],
+          buttons: [{ label: "Button 1" }],
         },
         {
           id: 2,
-          type: 'other',
-          content: 'Second',
-          rawContent: 'Second',
+          type: "other",
+          content: "Second",
+          rawContent: "Second",
           timestamp: new Date(),
-          buttons: [{ label: 'Button 2' }],
+          buttons: [{ label: "Button 2" }],
         },
       ]);
 
@@ -247,36 +275,36 @@ describe('Chat Store Unit Tests', () => {
       expect(messages[1]?.buttons).toEqual([]);
     });
 
-    it('should work with messages that have no buttons', () => {
+    it("should work with messages that have no buttons", () => {
       const store = useChatStore.getState();
 
-      store.addMessage({ type: 'self', content: 'No buttons' });
+      store.addMessage({ type: "self", content: "No buttons" });
       store.clearButtons();
 
       expect(store.getMessages()[0]?.buttons).toEqual([]);
     });
   });
 
-  describe('clearPreviousMessageButtons', () => {
-    it('should remove buttons from last message only', () => {
+  describe("clearPreviousMessageButtons", () => {
+    it("should remove buttons from last message only", () => {
       const store = useChatStore.getState();
 
       store.setMessages([
         {
           id: 1,
-          type: 'other',
-          content: 'First',
-          rawContent: 'First',
+          type: "other",
+          content: "First",
+          rawContent: "First",
           timestamp: new Date(),
-          buttons: [{ label: 'Button 1' }],
+          buttons: [{ label: "Button 1" }],
         },
         {
           id: 2,
-          type: 'other',
-          content: 'Second',
-          rawContent: 'Second',
+          type: "other",
+          content: "Second",
+          rawContent: "Second",
           timestamp: new Date(),
-          buttons: [{ label: 'Button 2' }],
+          buttons: [{ label: "Button 2" }],
         },
       ]);
 
@@ -287,23 +315,23 @@ describe('Chat Store Unit Tests', () => {
       expect(messages[1]?.buttons).toEqual([]);
     });
 
-    it('should do nothing when no messages', () => {
+    it("should do nothing when no messages", () => {
       const store = useChatStore.getState();
       expect(() => store.clearPreviousMessageButtons()).not.toThrow();
     });
   });
 
-  describe('clearPreviousMessageCallback', () => {
-    it('should remove callback from last message', () => {
+  describe("clearPreviousMessageCallback", () => {
+    it("should remove callback from last message", () => {
       const store = useChatStore.getState();
       const callback = vi.fn();
 
       store.setMessages([
         {
           id: 1,
-          type: 'other',
-          content: 'Message',
-          rawContent: 'Message',
+          type: "other",
+          content: "Message",
+          rawContent: "Message",
           timestamp: new Date(),
           userResponseCallback: callback,
         },
@@ -316,7 +344,7 @@ describe('Chat Store Unit Tests', () => {
       expect(store.getPreviousMessage()?.userResponseCallback).toBeUndefined();
     });
 
-    it('should only remove callback from last message', () => {
+    it("should only remove callback from last message", () => {
       const store = useChatStore.getState();
       const callback1 = vi.fn();
       const callback2 = vi.fn();
@@ -324,17 +352,17 @@ describe('Chat Store Unit Tests', () => {
       store.setMessages([
         {
           id: 1,
-          type: 'other',
-          content: 'First',
-          rawContent: 'First',
+          type: "other",
+          content: "First",
+          rawContent: "First",
           timestamp: new Date(),
           userResponseCallback: callback1,
         },
         {
           id: 2,
-          type: 'other',
-          content: 'Second',
-          rawContent: 'Second',
+          type: "other",
+          content: "Second",
+          rawContent: "Second",
           timestamp: new Date(),
           userResponseCallback: callback2,
         },
@@ -347,7 +375,7 @@ describe('Chat Store Unit Tests', () => {
       expect(messages[1]?.userResponseCallback).toBeUndefined();
     });
 
-    it('should do nothing when no messages', () => {
+    it("should do nothing when no messages", () => {
       const store = useChatStore.getState();
       expect(() => store.clearPreviousMessageCallback()).not.toThrow();
     });

--- a/src/__tests__/requestButtonDefinitions.test.ts
+++ b/src/__tests__/requestButtonDefinitions.test.ts
@@ -1,14 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createButton,
   createRequestConfirmationButtonDef,
   createRequestInputButtonDef,
-} from "../index";
-import { useChatStore } from "../lib/chatStore";
-import { useInputFieldStore } from "../lib/inputFieldStore";
-import { usePersistentButtonStore } from "../lib/persistentButtonStore";
+} from '../index';
+import { useChatStore } from '../lib/chatStore';
+import { useInputFieldStore } from '../lib/inputFieldStore';
+import { usePersistentButtonStore } from '../lib/persistentButtonStore';
 
-describe("request button definitions", () => {
+describe('request button definitions', () => {
   beforeEach(() => {
     useChatStore.getState().clearMessages();
     usePersistentButtonStore.getState().clearButtons();
@@ -19,42 +19,42 @@ describe("request button definitions", () => {
     useInputFieldStore.getState().resetInputFieldValidator();
   });
 
-  it("creates an input button from a reusable definition", () => {
+  it('creates an input button from a reusable definition', () => {
     const onValidInput = vi.fn();
     const definition = createRequestInputButtonDef({
-      initialLabel: "Change Email",
-      inputPromptMessage: "Enter your new email address.",
-      inputType: "email",
-      placeholder: "email@example.com",
-      inputDescription: "We will send a verification link to this address.",
+      initialLabel: 'Change Email',
+      inputPromptMessage: 'Enter your new email address.',
+      inputType: 'email',
+      placeholder: 'email@example.com',
+      inputDescription: 'We will send a verification link to this address.',
     });
 
     const button = createButton(definition, {
       onValidInput,
     });
 
-    expect(button.label).toBe("Change Email");
+    expect(button.label).toBe('Change Email');
 
     button.onClick?.();
 
     const [message] = useChatStore.getState().getMessages();
-    expect(message?.content).toBe("Enter your new email address.");
-    expect(useInputFieldStore.getState().getInputFieldType()).toBe("email");
+    expect(message?.content).toBe('Enter your new email address.');
+    expect(useInputFieldStore.getState().getInputFieldType()).toBe('email');
     expect(useInputFieldStore.getState().getInputFieldPlaceholder()).toBe(
-      "email@example.com",
+      'email@example.com'
     );
     expect(useInputFieldStore.getState().getInputFieldDescription()).toBe(
-      "We will send a verification link to this address.",
+      'We will send a verification link to this address.'
     );
     expect(usePersistentButtonStore.getState().getButtons()).toHaveLength(1);
   });
 
-  it("runs input success callbacks defined on the button definition", () => {
+  it('runs input success callbacks defined on the button definition', () => {
     const onSuccess = vi.fn();
     const onValidInput = vi.fn();
     const definition = createRequestInputButtonDef({
-      initialLabel: "Change Email",
-      inputPromptMessage: "Enter your new email address.",
+      initialLabel: 'Change Email',
+      inputPromptMessage: 'Enter your new email address.',
       onSuccess,
     });
 
@@ -65,28 +65,28 @@ describe("request button definitions", () => {
     button.onClick?.();
 
     useChatStore.getState().addMessage({
-      type: "self",
-      content: "new@example.com",
-      rawContent: "new@example.com",
+      type: 'self',
+      content: 'new@example.com',
+      rawContent: 'new@example.com',
     });
 
     const messages = useChatStore.getState().getMessages();
-    const promptMessage = messages.find((message) => message.type === "other");
+    const promptMessage = messages.find(message => message.type === 'other');
     promptMessage?.userResponseCallback?.();
 
-    expect(onSuccess).toHaveBeenCalledWith("new@example.com");
-    expect(onValidInput).toHaveBeenCalledWith("new@example.com");
+    expect(onSuccess).toHaveBeenCalledWith('new@example.com');
+    expect(onValidInput).toHaveBeenCalledWith('new@example.com');
   });
 
-  it("creates a confirmation button from a reusable definition", () => {
+  it('creates a confirmation button from a reusable definition', () => {
     const onConfirm = vi.fn();
     const onReject = vi.fn();
     const definition = createRequestConfirmationButtonDef({
-      initialLabel: "Logout",
-      confirmationMessage: "Are you sure you want to logout?",
-      confirmLabel: "Yes, Logout",
-      rejectLabel: "Cancel",
-      variant: "error",
+      initialLabel: 'Logout',
+      confirmationMessage: 'Are you sure you want to logout?',
+      confirmLabel: 'Yes, Logout',
+      rejectLabel: 'Cancel',
+      variant: 'error',
     });
 
     const button = createButton(definition, {
@@ -94,26 +94,26 @@ describe("request button definitions", () => {
       onReject,
     });
 
-    expect(button.label).toBe("Logout");
-    expect(button.variant).toBe("error");
+    expect(button.label).toBe('Logout');
+    expect(button.variant).toBe('error');
 
     button.onClick?.();
 
     const [message] = useChatStore.getState().getMessages();
-    expect(message?.content).toBe("Are you sure you want to logout?");
+    expect(message?.content).toBe('Are you sure you want to logout?');
     expect(message?.buttons).toHaveLength(2);
-    expect(message?.buttons?.map((candidate) => candidate.label)).toEqual([
-      "Yes, Logout",
-      "Cancel",
+    expect(message?.buttons?.map(candidate => candidate.label)).toEqual([
+      'Yes, Logout',
+      'Cancel',
     ]);
   });
 
-  it("runs confirmation success callbacks defined on the button definition", () => {
+  it('runs confirmation success callbacks defined on the button definition', () => {
     const onSuccess = vi.fn();
     const onConfirm = vi.fn();
     const definition = createRequestConfirmationButtonDef({
-      initialLabel: "Logout",
-      confirmationMessage: "Are you sure you want to logout?",
+      initialLabel: 'Logout',
+      confirmationMessage: 'Are you sure you want to logout?',
       onSuccess,
     });
 
@@ -131,25 +131,25 @@ describe("request button definitions", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps an id from createButton or the definition", () => {
+  it('keeps an id from createButton or the definition', () => {
     const definedIdButton = createButton(
       createRequestInputButtonDef({
-        id: "change-email",
-        initialLabel: "Change Email",
-        inputPromptMessage: "Enter your new email address.",
+        id: 'change-email',
+        initialLabel: 'Change Email',
+        inputPromptMessage: 'Enter your new email address.',
       }),
-      {},
+      {}
     );
     const runtimeIdButton = createButton(
       {
-        label: "Open help",
+        label: 'Open help',
       },
       {
-        id: "open-help",
-      },
+        id: 'open-help',
+      }
     );
 
-    expect(definedIdButton).toHaveProperty("id", "change-email");
-    expect(runtimeIdButton).toHaveProperty("id", "open-help");
+    expect(definedIdButton).toHaveProperty('id', 'change-email');
+    expect(runtimeIdButton).toHaveProperty('id', 'open-help');
   });
 });

--- a/src/__tests__/requestButtonDefinitions.test.ts
+++ b/src/__tests__/requestButtonDefinitions.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createButton,
+  createRequestConfirmationButtonDef,
+  createRequestInputButtonDef,
+} from "../index";
+import { useChatStore } from "../lib/chatStore";
+import { useInputFieldStore } from "../lib/inputFieldStore";
+import { usePersistentButtonStore } from "../lib/persistentButtonStore";
+
+describe("request button definitions", () => {
+  beforeEach(() => {
+    useChatStore.getState().clearMessages();
+    usePersistentButtonStore.getState().clearButtons();
+    useInputFieldStore.getState().resetInputFieldValue();
+    useInputFieldStore.getState().resetInputFieldDescription();
+    useInputFieldStore.getState().resetInputFieldType();
+    useInputFieldStore.getState().resetInputFieldPlaceholder();
+    useInputFieldStore.getState().resetInputFieldValidator();
+  });
+
+  it("creates an input button from a reusable definition", () => {
+    const onValidInput = vi.fn();
+    const definition = createRequestInputButtonDef({
+      initialLabel: "Change Email",
+      inputPromptMessage: "Enter your new email address.",
+      inputType: "email",
+      placeholder: "email@example.com",
+      inputDescription: "We will send a verification link to this address.",
+    });
+
+    const button = createButton(definition, {
+      onValidInput,
+    });
+
+    expect(button.label).toBe("Change Email");
+
+    button.onClick?.();
+
+    const [message] = useChatStore.getState().getMessages();
+    expect(message?.content).toBe("Enter your new email address.");
+    expect(useInputFieldStore.getState().getInputFieldType()).toBe("email");
+    expect(useInputFieldStore.getState().getInputFieldPlaceholder()).toBe(
+      "email@example.com",
+    );
+    expect(useInputFieldStore.getState().getInputFieldDescription()).toBe(
+      "We will send a verification link to this address.",
+    );
+    expect(usePersistentButtonStore.getState().getButtons()).toHaveLength(1);
+  });
+
+  it("runs input success callbacks defined on the button definition", () => {
+    const onSuccess = vi.fn();
+    const onValidInput = vi.fn();
+    const definition = createRequestInputButtonDef({
+      initialLabel: "Change Email",
+      inputPromptMessage: "Enter your new email address.",
+      onSuccess,
+    });
+
+    const button = createButton(definition, {
+      onValidInput,
+    });
+
+    button.onClick?.();
+
+    useChatStore.getState().addMessage({
+      type: "self",
+      content: "new@example.com",
+      rawContent: "new@example.com",
+    });
+
+    const messages = useChatStore.getState().getMessages();
+    const promptMessage = messages.find((message) => message.type === "other");
+    promptMessage?.userResponseCallback?.();
+
+    expect(onSuccess).toHaveBeenCalledWith("new@example.com");
+    expect(onValidInput).toHaveBeenCalledWith("new@example.com");
+  });
+
+  it("creates a confirmation button from a reusable definition", () => {
+    const onConfirm = vi.fn();
+    const onReject = vi.fn();
+    const definition = createRequestConfirmationButtonDef({
+      initialLabel: "Logout",
+      confirmationMessage: "Are you sure you want to logout?",
+      confirmLabel: "Yes, Logout",
+      rejectLabel: "Cancel",
+      variant: "error",
+    });
+
+    const button = createButton(definition, {
+      onConfirm,
+      onReject,
+    });
+
+    expect(button.label).toBe("Logout");
+    expect(button.variant).toBe("error");
+
+    button.onClick?.();
+
+    const [message] = useChatStore.getState().getMessages();
+    expect(message?.content).toBe("Are you sure you want to logout?");
+    expect(message?.buttons).toHaveLength(2);
+    expect(message?.buttons?.map((candidate) => candidate.label)).toEqual([
+      "Yes, Logout",
+      "Cancel",
+    ]);
+  });
+
+  it("runs confirmation success callbacks defined on the button definition", () => {
+    const onSuccess = vi.fn();
+    const onConfirm = vi.fn();
+    const definition = createRequestConfirmationButtonDef({
+      initialLabel: "Logout",
+      confirmationMessage: "Are you sure you want to logout?",
+      onSuccess,
+    });
+
+    const button = createButton(definition, {
+      onConfirm,
+    });
+
+    button.onClick?.();
+
+    const [message] = useChatStore.getState().getMessages();
+    const confirmButton = message?.buttons?.[0];
+    confirmButton?.onClick?.();
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an id from createButton or the definition", () => {
+    const definedIdButton = createButton(
+      createRequestInputButtonDef({
+        id: "change-email",
+        initialLabel: "Change Email",
+        inputPromptMessage: "Enter your new email address.",
+      }),
+      {},
+    );
+    const runtimeIdButton = createButton(
+      {
+        label: "Open help",
+      },
+      {
+        id: "open-help",
+      },
+    );
+
+    expect(definedIdButton).toHaveProperty("id", "change-email");
+    expect(runtimeIdButton).toHaveProperty("id", "open-help");
+  });
+});

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -12,8 +12,6 @@ import { MessagesList, ChatInput, PersistentButtons } from './';
  * Renders the chat UI and wires user input into the shared chat state.
  *
  * @param props The chat component props.
- * @param props.initialMessages Optional messages shown when the chat first renders.
- * @param props.theme Optional preset or theme object used to style the chat UI.
  */
 export function Chat({
   initialMessages = [],

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,12 +1,12 @@
-import { useEffect } from 'react';
-import type { ChatPropsWithFlexibleTheme } from '../js/types';
+import { useEffect } from "react";
+import type { ChatPropsWithFlexibleTheme } from "../js/types";
 import {
   useChatStore,
   getResolvedTheme,
   getThemeStyles,
   useInputFieldStore,
-} from '../lib';
-import { MessagesList, ChatInput, PersistentButtons } from './';
+} from "../lib";
+import { MessagesList, ChatInput, PersistentButtons } from "./";
 
 export function Chat({
   initialMessages = [],
@@ -14,6 +14,8 @@ export function Chat({
 }: ChatPropsWithFlexibleTheme): React.JSX.Element {
   const {
     messages,
+    isLoading,
+    loadingMessage,
     addMessage,
     addMessages,
     getPreviousMessage,
@@ -37,19 +39,19 @@ export function Chat({
     const previousMessage = getPreviousMessage();
 
     let displayedContent = messageContent;
-    if (getInputFieldType() === 'password') {
-      displayedContent = '•'.repeat(messageContent.length);
+    if (getInputFieldType() === "password") {
+      displayedContent = "•".repeat(messageContent.length);
     }
 
     // Add the self message
     addMessage({
-      type: 'self',
+      type: "self",
       content: displayedContent,
       rawContent: messageContent,
     });
 
     // If the previous message is an other message and has a userResponseCallback, call it
-    const isPreviousMessageOther = previousMessage?.type === 'other';
+    const isPreviousMessageOther = previousMessage?.type === "other";
     const hasUserResponseCallback = previousMessage?.userResponseCallback;
     if (isPreviousMessageOther && hasUserResponseCallback) {
       previousMessage.userResponseCallback();
@@ -57,16 +59,21 @@ export function Chat({
   };
 
   return (
-    <div className='asc-chat-wrapper'>
+    <div className="asc-chat-wrapper">
       <div
-        className='flex h-screen flex-col'
+        className="flex h-screen flex-col"
         style={{
           ...getThemeStyles(mergedTheme),
           backgroundColor: mergedTheme.backgroundColor,
           color: mergedTheme.textColor,
         }}
       >
-        <MessagesList messages={messages} theme={mergedTheme} />
+        <MessagesList
+          messages={messages}
+          isLoading={isLoading}
+          loadingMessage={loadingMessage}
+          theme={mergedTheme}
+        />
         <PersistentButtons theme={mergedTheme} />
         <ChatInput onSend={handleSend} theme={mergedTheme} />
       </div>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -11,7 +11,7 @@ import { MessagesList, ChatInput, PersistentButtons } from './';
 /**
  * Renders the chat UI and wires user input into the shared chat state.
  *
- * @param props The chat component props.
+ * @param props The `ChatPropsWithFlexibleTheme` object.
  */
 export function Chat({
   initialMessages = [],

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import type { ChatPropsWithFlexibleTheme } from '../js/types';
 import {
   useChatStore,
@@ -15,7 +15,6 @@ export function Chat({
   const {
     messages,
     isLoading,
-    loadingMessage,
     addMessage,
     addMessages,
     getPreviousMessage,
@@ -71,7 +70,6 @@ export function Chat({
         <MessagesList
           messages={messages}
           isLoading={isLoading}
-          loadingMessage={loadingMessage}
           theme={mergedTheme}
         />
         <PersistentButtons theme={mergedTheme} />

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -8,6 +8,13 @@ import {
 } from '../lib';
 import { MessagesList, ChatInput, PersistentButtons } from './';
 
+/**
+ * Renders the chat UI and wires user input into the shared chat state.
+ *
+ * @param props The chat component props.
+ * @param props.initialMessages Optional messages shown when the chat first renders.
+ * @param props.theme Optional preset or theme object used to style the chat UI.
+ */
 export function Chat({
   initialMessages = [],
   theme,

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,12 +1,12 @@
-import { useEffect } from "react";
-import type { ChatPropsWithFlexibleTheme } from "../js/types";
+import { useEffect } from 'react';
+import type { ChatPropsWithFlexibleTheme } from '../js/types';
 import {
   useChatStore,
   getResolvedTheme,
   getThemeStyles,
   useInputFieldStore,
-} from "../lib";
-import { MessagesList, ChatInput, PersistentButtons } from "./";
+} from '../lib';
+import { MessagesList, ChatInput, PersistentButtons } from './';
 
 export function Chat({
   initialMessages = [],
@@ -39,19 +39,19 @@ export function Chat({
     const previousMessage = getPreviousMessage();
 
     let displayedContent = messageContent;
-    if (getInputFieldType() === "password") {
-      displayedContent = "•".repeat(messageContent.length);
+    if (getInputFieldType() === 'password') {
+      displayedContent = '•'.repeat(messageContent.length);
     }
 
     // Add the self message
     addMessage({
-      type: "self",
+      type: 'self',
       content: displayedContent,
       rawContent: messageContent,
     });
 
     // If the previous message is an other message and has a userResponseCallback, call it
-    const isPreviousMessageOther = previousMessage?.type === "other";
+    const isPreviousMessageOther = previousMessage?.type === 'other';
     const hasUserResponseCallback = previousMessage?.userResponseCallback;
     if (isPreviousMessageOther && hasUserResponseCallback) {
       previousMessage.userResponseCallback();
@@ -59,9 +59,9 @@ export function Chat({
   };
 
   return (
-    <div className="asc-chat-wrapper">
+    <div className='asc-chat-wrapper'>
       <div
-        className="flex h-screen flex-col"
+        className='flex h-screen flex-col'
         style={{
           ...getThemeStyles(mergedTheme),
           backgroundColor: mergedTheme.backgroundColor,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -19,7 +19,7 @@ interface ChatInputProps {
 /**
  * Renders the shared chat input field and submit button.
  *
- * @param props The chat input props.
+ * @param props The `ChatInputProps` object.
  */
 export function ChatInput({
   onSend,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
 import { Send } from 'lucide-react';
 import type { ChatTheme } from '../js/types';

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -20,8 +20,6 @@ interface ChatInputProps {
  * Renders the shared chat input field and submit button.
  *
  * @param props The chat input props.
- * @param props.onSend Called when the user submits the current input value.
- * @param props.theme Theme tokens used to style the input area and send button.
  */
 export function ChatInput({
   onSend,

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -6,7 +6,9 @@ import { Button } from './ui/button';
 import { useInputFieldStore } from '../lib/inputFieldStore';
 
 interface ChatInputProps {
+  /** Called when the user submits the current input value. */
   readonly onSend: (message: string) => void;
+  /** Theme tokens used to style the input area and send button. */
   readonly theme: ChatTheme;
 }
 

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -5,13 +5,24 @@ import type { ChatTheme } from '../js/types';
 import { Button } from './ui/button';
 import { useInputFieldStore } from '../lib/inputFieldStore';
 
+/**
+ * Props for the shared chat input field.
+ *
+ * @property onSend Called when the user submits the current input value.
+ * @property theme Theme tokens used to style the input area and send button.
+ */
 interface ChatInputProps {
-  /** Called when the user submits the current input value. */
   readonly onSend: (message: string) => void;
-  /** Theme tokens used to style the input area and send button. */
   readonly theme: ChatTheme;
 }
 
+/**
+ * Renders the shared chat input field and submit button.
+ *
+ * @param props The chat input props.
+ * @param props.onSend Called when the user submits the current input value.
+ * @param props.theme Theme tokens used to style the input area and send button.
+ */
 export function ChatInput({
   onSend,
   theme,

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -14,7 +14,6 @@ interface LoadingIndicatorProps {
  * Lightweight chat loading indicator shown while async work is in progress.
  *
  * @param props The loading indicator props.
- * @param props.theme Theme tokens used to style the indicator.
  */
 export function LoadingIndicator({
   theme,

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import type { ChatTheme } from "../js/types";
+
+interface LoadingIndicatorProps {
+  readonly label?: string | undefined;
+  readonly theme: ChatTheme;
+  readonly bubble?: boolean | undefined;
+}
+
+/**
+ * Lightweight chat loading indicator shown while async work is in progress.
+ */
+export function LoadingIndicator({
+  label,
+  theme,
+  bubble = true,
+}: LoadingIndicatorProps): React.JSX.Element {
+  const [visibleDotCount, setVisibleDotCount] = useState(1);
+  const accessibleLabel = label && label.trim() !== "" ? label : "Loading";
+
+  useEffect(() => {
+    const intervalId = globalThis.setInterval(() => {
+      setVisibleDotCount((currentCount) =>
+        currentCount === 3 ? 1 : currentCount + 1,
+      );
+    }, 240);
+
+    return () => {
+      globalThis.clearInterval(intervalId);
+    };
+  }, []);
+
+  const dots = (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={accessibleLabel}
+      className="flex items-center text-sm leading-relaxed"
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex min-w-[1.8rem] font-mono text-base font-semibold"
+        style={{
+          color: theme.textColor,
+        }}
+      >
+        {[0, 1, 2].map((index) => (
+          <span
+            key={index}
+            style={{
+              visibility: index < visibleDotCount ? "visible" : "hidden",
+            }}
+          >
+            .
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+
+  if (!bubble) {
+    return dots;
+  }
+
+  return (
+    <div className="mb-1 flex gap-3">
+      <div className="max-w-[85%]">
+        <div
+          className="mr-auto rounded-lg px-4 py-3 shadow-sm"
+          style={{
+            background: `${theme.secondaryColor}f5`,
+            color: theme.textColor,
+            maxWidth: "fit-content",
+          }}
+        >
+          {dots}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,25 +1,18 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { ChatTheme } from '../js/types';
 
 interface LoadingIndicatorProps {
-  /** Optional status text announced to assistive technology while loading. */
-  readonly label?: string | undefined;
   /** Theme tokens used to style the indicator. */
   readonly theme: ChatTheme;
-  /** Renders the indicator inside a chat bubble when true. */
-  readonly bubble?: boolean | undefined;
 }
 
 /**
  * Lightweight chat loading indicator shown while async work is in progress.
  */
 export function LoadingIndicator({
-  label,
   theme,
-  bubble = true,
 }: LoadingIndicatorProps): React.JSX.Element {
   const [visibleDotCount, setVisibleDotCount] = useState(1);
-  const accessibleLabel = label && label.trim() !== '' ? label : 'Loading';
 
   useEffect(() => {
     const intervalId = globalThis.setInterval(() => {
@@ -37,7 +30,7 @@ export function LoadingIndicator({
     <div
       role='status'
       aria-live='polite'
-      aria-label={accessibleLabel}
+      aria-label='Loading'
       className='flex items-center text-sm leading-relaxed'
     >
       <span
@@ -61,24 +54,5 @@ export function LoadingIndicator({
     </div>
   );
 
-  if (!bubble) {
-    return dots;
-  }
-
-  return (
-    <div className='mb-1 flex gap-3'>
-      <div className='max-w-[85%]'>
-        <div
-          className='mr-auto rounded-lg px-4 py-3 shadow-sm'
-          style={{
-            background: `${theme.secondaryColor}f5`,
-            color: theme.textColor,
-            maxWidth: 'fit-content',
-          }}
-        >
-          {dots}
-        </div>
-      </div>
-    </div>
-  );
+  return dots;
 }

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -13,7 +13,7 @@ interface LoadingIndicatorProps {
 /**
  * Lightweight chat loading indicator shown while async work is in progress.
  *
- * @param props The loading indicator props.
+ * @param props The `LoadingIndicatorProps` object.
  */
 export function LoadingIndicator({
   theme,

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import type { ChatTheme } from "../js/types";
+import { useEffect, useState } from 'react';
+import type { ChatTheme } from '../js/types';
 
 interface LoadingIndicatorProps {
   readonly label?: string | undefined;
@@ -16,12 +16,12 @@ export function LoadingIndicator({
   bubble = true,
 }: LoadingIndicatorProps): React.JSX.Element {
   const [visibleDotCount, setVisibleDotCount] = useState(1);
-  const accessibleLabel = label && label.trim() !== "" ? label : "Loading";
+  const accessibleLabel = label && label.trim() !== '' ? label : 'Loading';
 
   useEffect(() => {
     const intervalId = globalThis.setInterval(() => {
-      setVisibleDotCount((currentCount) =>
-        currentCount === 3 ? 1 : currentCount + 1,
+      setVisibleDotCount(currentCount =>
+        currentCount === 3 ? 1 : currentCount + 1
       );
     }, 240);
 
@@ -32,23 +32,23 @@ export function LoadingIndicator({
 
   const dots = (
     <div
-      role="status"
-      aria-live="polite"
+      role='status'
+      aria-live='polite'
       aria-label={accessibleLabel}
-      className="flex items-center text-sm leading-relaxed"
+      className='flex items-center text-sm leading-relaxed'
     >
       <span
-        aria-hidden="true"
-        className="inline-flex min-w-[1.8rem] font-mono text-base font-semibold"
+        aria-hidden='true'
+        className='inline-flex min-w-[1.8rem] font-mono text-base font-semibold'
         style={{
           color: theme.textColor,
         }}
       >
-        {[0, 1, 2].map((index) => (
+        {[0, 1, 2].map(index => (
           <span
             key={index}
             style={{
-              visibility: index < visibleDotCount ? "visible" : "hidden",
+              visibility: index < visibleDotCount ? 'visible' : 'hidden',
             }}
           >
             .
@@ -63,14 +63,14 @@ export function LoadingIndicator({
   }
 
   return (
-    <div className="mb-1 flex gap-3">
-      <div className="max-w-[85%]">
+    <div className='mb-1 flex gap-3'>
+      <div className='max-w-[85%]'>
         <div
-          className="mr-auto rounded-lg px-4 py-3 shadow-sm"
+          className='mr-auto rounded-lg px-4 py-3 shadow-sm'
           style={{
             background: `${theme.secondaryColor}f5`,
             color: theme.textColor,
-            maxWidth: "fit-content",
+            maxWidth: 'fit-content',
           }}
         >
           {dots}

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,13 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import type { ChatTheme } from '../js/types';
 
+/**
+ * Props for the loading indicator.
+ *
+ * @property theme Theme tokens used to style the indicator.
+ */
 interface LoadingIndicatorProps {
-  /** Theme tokens used to style the indicator. */
   readonly theme: ChatTheme;
 }
 
 /**
  * Lightweight chat loading indicator shown while async work is in progress.
+ *
+ * @param props The loading indicator props.
+ * @param props.theme Theme tokens used to style the indicator.
  */
 export function LoadingIndicator({
   theme,

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -2,8 +2,11 @@ import { useEffect, useState } from 'react';
 import type { ChatTheme } from '../js/types';
 
 interface LoadingIndicatorProps {
+  /** Optional status text announced to assistive technology while loading. */
   readonly label?: string | undefined;
+  /** Theme tokens used to style the indicator. */
   readonly theme: ChatTheme;
+  /** Renders the indicator inside a chat bubble when true. */
   readonly bubble?: boolean | undefined;
 }
 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -17,7 +17,7 @@ interface MessageBubbleProps {
 /**
  * Renders a single chat bubble with its timestamp and optional actions.
  *
- * @param props The message bubble props.
+ * @param props The `MessageBubbleProps` object.
  */
 export function MessageBubble({
   message,

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -18,8 +18,6 @@ interface MessageBubbleProps {
  * Renders a single chat bubble with its timestamp and optional actions.
  *
  * @param props The message bubble props.
- * @param props.message Message data to render, including content, metadata, and actions.
- * @param props.theme Theme tokens used to style the bubble and text colors.
  */
 export function MessageBubble({
   message,

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -3,13 +3,24 @@ import type { ChatTheme, Message } from '../js/types';
 import { LoadingIndicator } from './LoadingIndicator';
 import { MessageButtons } from './MessageButtons';
 
+/**
+ * Props for a single chat bubble.
+ *
+ * @property message Message data to render, including content, metadata, and actions.
+ * @property theme Theme tokens used to style the bubble and text colors.
+ */
 interface MessageBubbleProps {
-  /** Message data to render, including content, metadata, and actions. */
   readonly message: Message;
-  /** Theme tokens used to style the bubble and text colors. */
   readonly theme: ChatTheme;
 }
 
+/**
+ * Renders a single chat bubble with its timestamp and optional actions.
+ *
+ * @param props The message bubble props.
+ * @param props.message Message data to render, including content, metadata, and actions.
+ * @param props.theme Theme tokens used to style the bubble and text colors.
+ */
 export function MessageBubble({
   message,
   theme,

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { ChatTheme, Message } from '../js/types';
 import { LoadingIndicator } from './LoadingIndicator';
 import { MessageButtons } from './MessageButtons';
@@ -37,11 +38,7 @@ export function MessageBubble({
           }}
         >
           {isLoadingMessage ? (
-            <LoadingIndicator
-              bubble={false}
-              label={message.loadingLabel}
-              theme={theme}
-            />
+            <LoadingIndicator theme={theme} />
           ) : (
             <>
               <p className='wrap-break-words text-sm leading-relaxed'>

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -3,7 +3,9 @@ import { LoadingIndicator } from './LoadingIndicator';
 import { MessageButtons } from './MessageButtons';
 
 interface MessageBubbleProps {
+  /** Message data to render, including content, metadata, and actions. */
   readonly message: Message;
+  /** Theme tokens used to style the bubble and text colors. */
   readonly theme: ChatTheme;
 }
 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import type { ChatTheme, Message } from '../js/types';
+import { LoadingIndicator } from './LoadingIndicator';
 import { MessageButtons } from './MessageButtons';
 
 interface MessageBubbleProps {
@@ -10,6 +11,8 @@ export function MessageBubble({
   message,
   theme,
 }: MessageBubbleProps): React.JSX.Element {
+  const isLoadingMessage = message.isLoading === true;
+
   return (
     <div
       className={`mb-1 flex gap-3 ${
@@ -31,23 +34,33 @@ export function MessageBubble({
             maxWidth: message.type === 'self' ? 'fit-content' : '100%',
           }}
         >
-          <p className='wrap-break-words text-sm leading-relaxed'>
-            {message.content}
-          </p>
-          <span
-            className='mt-1.5 block text-xs'
-            style={{
-              color:
-                message.type === 'self'
-                  ? `${theme.buttonTextColor}70`
-                  : `${theme.textColor}60`,
-            }}
-          >
-            {message.timestamp.toLocaleTimeString([], {
-              hour: '2-digit',
-              minute: '2-digit',
-            })}
-          </span>
+          {isLoadingMessage ? (
+            <LoadingIndicator
+              bubble={false}
+              label={message.loadingLabel}
+              theme={theme}
+            />
+          ) : (
+            <>
+              <p className='wrap-break-words text-sm leading-relaxed'>
+                {message.content}
+              </p>
+              <span
+                className='mt-1.5 block text-xs'
+                style={{
+                  color:
+                    message.type === 'self'
+                      ? `${theme.buttonTextColor}70`
+                      : `${theme.textColor}60`,
+                }}
+              >
+                {message.timestamp.toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            </>
+          )}
         </div>
         {/* Message Buttons */}
         <MessageButtons

--- a/src/components/MessageButtons.tsx
+++ b/src/components/MessageButtons.tsx
@@ -72,9 +72,6 @@ function getButtonVariantStyles(
  * Renders the action buttons attached to a single message.
  *
  * @param props The message button group props.
- * @param props.buttons Action buttons attached to the message.
- * @param props.messageType Message side used to align the buttons with the bubble.
- * @param props.theme Theme tokens used to style button colors.
  */
 export function MessageButtons({
   buttons,

--- a/src/components/MessageButtons.tsx
+++ b/src/components/MessageButtons.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type {
   InputMessage,
   ChatTheme,

--- a/src/components/MessageButtons.tsx
+++ b/src/components/MessageButtons.tsx
@@ -6,8 +6,11 @@ import type {
 import { cn } from '../lib/utils';
 
 interface MessageButtonsProps {
+  /** Action buttons attached to the message. */
   readonly buttons: InputMessage['buttons'];
+  /** Message side used to align the buttons with the bubble. */
   readonly messageType: InputMessage['type'];
+  /** Theme tokens used to style button colors. */
   readonly theme: ChatTheme;
 }
 

--- a/src/components/MessageButtons.tsx
+++ b/src/components/MessageButtons.tsx
@@ -6,12 +6,16 @@ import type {
 } from '../js/types';
 import { cn } from '../lib/utils';
 
+/**
+ * Props for the action buttons shown below a message.
+ *
+ * @property buttons Action buttons attached to the message.
+ * @property messageType Message side used to align the buttons with the bubble.
+ * @property theme Theme tokens used to style button colors.
+ */
 interface MessageButtonsProps {
-  /** Action buttons attached to the message. */
   readonly buttons: InputMessage['buttons'];
-  /** Message side used to align the buttons with the bubble. */
   readonly messageType: InputMessage['type'];
-  /** Theme tokens used to style button colors. */
   readonly theme: ChatTheme;
 }
 
@@ -64,6 +68,14 @@ function getButtonVariantStyles(
   }
 }
 
+/**
+ * Renders the action buttons attached to a single message.
+ *
+ * @param props The message button group props.
+ * @param props.buttons Action buttons attached to the message.
+ * @param props.messageType Message side used to align the buttons with the bubble.
+ * @param props.theme Theme tokens used to style button colors.
+ */
 export function MessageButtons({
   buttons,
   messageType,

--- a/src/components/MessageButtons.tsx
+++ b/src/components/MessageButtons.tsx
@@ -71,7 +71,7 @@ function getButtonVariantStyles(
 /**
  * Renders the action buttons attached to a single message.
  *
- * @param props The message button group props.
+ * @param props The `MessageButtonsProps` object.
  */
 export function MessageButtons({
   buttons,

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -1,6 +1,6 @@
-import { useRef, useEffect } from "react";
-import type { ChatTheme, Message } from "../js/types";
-import { LoadingIndicator, MessageBubble } from "./";
+import { useRef, useEffect } from 'react';
+import type { ChatTheme, Message } from '../js/types';
+import { LoadingIndicator, MessageBubble } from './';
 
 interface MessagesListProps {
   readonly messages: readonly Message[];
@@ -18,7 +18,7 @@ export function MessagesList({
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = (): void => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   useEffect(() => {
@@ -26,8 +26,8 @@ export function MessagesList({
   }, [isLoading, loadingMessage, messages]);
 
   return (
-    <div className="flex-1 space-y-5 overflow-y-auto scroll-smooth p-6">
-      {messages.map((message) => (
+    <div className='flex-1 space-y-5 overflow-y-auto scroll-smooth p-6'>
+      {messages.map(message => (
         <MessageBubble key={message.id} message={message} theme={theme} />
       ))}
       {isLoading ? (

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -19,9 +19,6 @@ interface MessagesListProps {
  * Renders the chat transcript and keeps the latest content in view.
  *
  * @param props The message list props.
- * @param props.messages Messages to render in the chat transcript.
- * @param props.isLoading Shows the loading indicator below the transcript when true.
- * @param props.theme Theme tokens used to style message surfaces.
  */
 export function MessagesList({
   messages,

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -3,9 +3,13 @@ import type { ChatTheme, Message } from '../js/types';
 import { LoadingIndicator, MessageBubble } from './';
 
 interface MessagesListProps {
+  /** Messages to render in the chat transcript. */
   readonly messages: readonly Message[];
+  /** Shows the loading indicator below the transcript when true. */
   readonly isLoading?: boolean | undefined;
+  /** Optional label announced while the loading indicator is visible. */
   readonly loadingMessage?: string | undefined;
+  /** Theme tokens used to style message surfaces. */
   readonly theme: ChatTheme;
 }
 

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -1,14 +1,12 @@
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import type { ChatTheme, Message } from '../js/types';
-import { LoadingIndicator, MessageBubble } from './';
+import { MessageBubble } from './';
 
 interface MessagesListProps {
   /** Messages to render in the chat transcript. */
   readonly messages: readonly Message[];
   /** Shows the loading indicator below the transcript when true. */
   readonly isLoading?: boolean | undefined;
-  /** Optional label announced while the loading indicator is visible. */
-  readonly loadingMessage?: string | undefined;
   /** Theme tokens used to style message surfaces. */
   readonly theme: ChatTheme;
 }
@@ -16,10 +14,17 @@ interface MessagesListProps {
 export function MessagesList({
   messages,
   isLoading = false,
-  loadingMessage,
   theme,
 }: MessagesListProps): React.JSX.Element {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const loadingIndicatorBubble: Message = {
+    id: -1,
+    type: 'other',
+    content: '',
+    rawContent: '',
+    timestamp: new Date(0),
+    isLoading: true,
+  };
 
   const scrollToBottom = (): void => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -27,16 +32,17 @@ export function MessagesList({
 
   useEffect(() => {
     scrollToBottom();
-  }, [isLoading, loadingMessage, messages]);
+  }, [isLoading, messages]);
 
   return (
     <div className='flex-1 space-y-5 overflow-y-auto scroll-smooth p-6'>
       {messages.map(message => (
-        <MessageBubble key={message.id} message={message} theme={theme} />
+        <MessageBubble
+          key={message.id}
+          message={isLoading ? loadingIndicatorBubble : message}
+          theme={theme}
+        />
       ))}
-      {isLoading ? (
-        <LoadingIndicator label={loadingMessage} theme={theme} />
-      ) : null}
       <div ref={messagesEndRef} />
     </div>
   );

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -18,7 +18,7 @@ interface MessagesListProps {
 /**
  * Renders the chat transcript and keeps the latest content in view.
  *
- * @param props The message list props.
+ * @param props The `MessagesListProps` object.
  */
 export function MessagesList({
   messages,

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -1,31 +1,38 @@
-import { useRef, useEffect } from 'react';
-import type { ChatTheme, Message } from '../js/types';
-import { MessageBubble } from './';
+import { useRef, useEffect } from "react";
+import type { ChatTheme, Message } from "../js/types";
+import { LoadingIndicator, MessageBubble } from "./";
 
 interface MessagesListProps {
   readonly messages: readonly Message[];
+  readonly isLoading?: boolean | undefined;
+  readonly loadingMessage?: string | undefined;
   readonly theme: ChatTheme;
 }
 
 export function MessagesList({
   messages,
+  isLoading = false,
+  loadingMessage,
   theme,
 }: MessagesListProps): React.JSX.Element {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = (): void => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [isLoading, loadingMessage, messages]);
 
   return (
-    <div className='flex-1 space-y-5 overflow-y-auto scroll-smooth p-6'>
-      {messages.map(message => (
+    <div className="flex-1 space-y-5 overflow-y-auto scroll-smooth p-6">
+      {messages.map((message) => (
         <MessageBubble key={message.id} message={message} theme={theme} />
       ))}
+      {isLoading ? (
+        <LoadingIndicator label={loadingMessage} theme={theme} />
+      ) : null}
       <div ref={messagesEndRef} />
     </div>
   );

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -2,15 +2,27 @@ import React, { useRef, useEffect } from 'react';
 import type { ChatTheme, Message } from '../js/types';
 import { MessageBubble } from './';
 
+/**
+ * Props for the chat transcript list.
+ *
+ * @property messages Messages to render in the chat transcript.
+ * @property isLoading Shows the loading indicator below the transcript when true.
+ * @property theme Theme tokens used to style message surfaces.
+ */
 interface MessagesListProps {
-  /** Messages to render in the chat transcript. */
   readonly messages: readonly Message[];
-  /** Shows the loading indicator below the transcript when true. */
   readonly isLoading?: boolean | undefined;
-  /** Theme tokens used to style message surfaces. */
   readonly theme: ChatTheme;
 }
 
+/**
+ * Renders the chat transcript and keeps the latest content in view.
+ *
+ * @param props The message list props.
+ * @param props.messages Messages to render in the chat transcript.
+ * @param props.isLoading Shows the loading indicator below the transcript when true.
+ * @param props.theme Theme tokens used to style message surfaces.
+ */
 export function MessagesList({
   messages,
   isLoading = false,
@@ -37,12 +49,11 @@ export function MessagesList({
   return (
     <div className='flex-1 space-y-5 overflow-y-auto scroll-smooth p-6'>
       {messages.map(message => (
-        <MessageBubble
-          key={message.id}
-          message={isLoading ? loadingIndicatorBubble : message}
-          theme={theme}
-        />
+        <MessageBubble key={message.id} message={message} theme={theme} />
       ))}
+      {isLoading ? (
+        <MessageBubble message={loadingIndicatorBubble} theme={theme} />
+      ) : null}
       <div ref={messagesEndRef} />
     </div>
   );

--- a/src/components/PersistentButtons.tsx
+++ b/src/components/PersistentButtons.tsx
@@ -52,11 +52,21 @@ function getButtonVariantStyles(
   }
 }
 
+/**
+ * Props for the persistent action bar.
+ *
+ * @property theme Theme tokens used to style the persistent action bar and buttons.
+ */
 interface PersistentButtonsProps {
-  /** Theme tokens used to style the persistent action bar and buttons. */
   readonly theme: ChatTheme;
 }
 
+/**
+ * Renders the persistent action buttons shown above the input field.
+ *
+ * @param props The persistent button bar props.
+ * @param props.theme Theme tokens used to style the persistent action bar and buttons.
+ */
 export function PersistentButtons({
   theme,
 }: PersistentButtonsProps): React.JSX.Element | null {

--- a/src/components/PersistentButtons.tsx
+++ b/src/components/PersistentButtons.tsx
@@ -52,6 +52,7 @@ function getButtonVariantStyles(
 }
 
 interface PersistentButtonsProps {
+  /** Theme tokens used to style the persistent action bar and buttons. */
   readonly theme: ChatTheme;
 }
 

--- a/src/components/PersistentButtons.tsx
+++ b/src/components/PersistentButtons.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { ChatTheme, MessageButtonVariant } from '../js/types';
 import { usePersistentButtonStore } from '../lib';
 import { cn } from '../lib/utils';

--- a/src/components/PersistentButtons.tsx
+++ b/src/components/PersistentButtons.tsx
@@ -65,7 +65,6 @@ interface PersistentButtonsProps {
  * Renders the persistent action buttons shown above the input field.
  *
  * @param props The persistent button bar props.
- * @param props.theme Theme tokens used to style the persistent action bar and buttons.
  */
 export function PersistentButtons({
   theme,

--- a/src/components/PersistentButtons.tsx
+++ b/src/components/PersistentButtons.tsx
@@ -64,7 +64,7 @@ interface PersistentButtonsProps {
 /**
  * Renders the persistent action buttons shown above the input field.
  *
- * @param props The persistent button bar props.
+ * @param props The `PersistentButtonsProps` object.
  */
 export function PersistentButtons({
   theme,

--- a/src/components/RequestConfirmationButton.tsx
+++ b/src/components/RequestConfirmationButton.tsx
@@ -1,5 +1,5 @@
-import type { MessageButton, MessageButtonVariant } from "../js/types";
-import { useChatStore } from "../lib";
+import type { MessageButton, MessageButtonVariant } from '../js/types';
+import { useChatStore } from '../lib';
 
 export interface RequestConfirmationButtonConfig {
   /**
@@ -71,8 +71,8 @@ export interface RequestConfirmationButtonRuntimeConfig {
  * callbacks are attached by the app.
  */
 export interface RequestConfirmationButtonDefinition
-  extends Omit<RequestConfirmationButtonConfig, "onConfirm" | "onReject"> {
-  readonly kind: "request-confirmation";
+  extends Omit<RequestConfirmationButtonConfig, 'onConfirm' | 'onReject'> {
+  readonly kind: 'request-confirmation';
   readonly id?: string | undefined;
 
   /**
@@ -88,11 +88,11 @@ export interface RequestConfirmationButtonDefinition
  * pass this definition to createButton and provide runtime callbacks there.
  */
 export function createRequestConfirmationButtonDef(
-  definition: Omit<RequestConfirmationButtonDefinition, "kind">,
+  definition: Omit<RequestConfirmationButtonDefinition, 'kind'>
 ): RequestConfirmationButtonDefinition {
   return {
     ...definition,
-    kind: "request-confirmation",
+    kind: 'request-confirmation',
   };
 }
 
@@ -106,13 +106,13 @@ export function createRequestConfirmationButtonDef(
  * @returns A MessageButton configuration that can be used in a Message's buttons array
  */
 export function createRequestConfirmationButton(
-  config: RequestConfirmationButtonConfig,
+  config: RequestConfirmationButtonConfig
 ): MessageButton {
   const {
     initialLabel,
     confirmationMessage,
-    confirmLabel = "Confirm",
-    rejectLabel = "Decline",
+    confirmLabel = 'Confirm',
+    rejectLabel = 'Decline',
     onConfirm,
     onReject,
     variant,
@@ -130,19 +130,19 @@ export function createRequestConfirmationButton(
 
       // Add a followup message with the confirmation message and buttons
       addMessage({
-        type: "other",
-        content: confirmationMessage ?? "Are you sure you want to do this?",
+        type: 'other',
+        content: confirmationMessage ?? 'Are you sure you want to do this?',
         buttons: [
           {
             label: confirmLabel,
-            variant: "success",
+            variant: 'success',
             onClick: () => {
               onConfirm();
             },
           },
           {
             label: rejectLabel,
-            variant: "dull",
+            variant: 'dull',
             onClick: () => {
               if (onReject) {
                 onReject();

--- a/src/components/RequestConfirmationButton.tsx
+++ b/src/components/RequestConfirmationButton.tsx
@@ -58,7 +58,7 @@ export interface RequestConfirmationButtonDefinition
  * Creates a reusable definition for a confirmation request button. Apps can
  * pass this definition to createButton and provide runtime callbacks there.
  *
- * @param definition The static confirmation button settings.
+ * @param definition The `Omit<RequestConfirmationButtonDefinition, 'kind'>` object.
  */
 export function createRequestConfirmationButtonDef(
   definition: Omit<RequestConfirmationButtonDefinition, 'kind'>
@@ -75,7 +75,7 @@ export function createRequestConfirmationButtonDef(
  * When clicked, the initial button adds a followup message with confirmation buttons.
  * The user can then confirm or reject the action, triggering the respective callbacks.
  *
- * @param config Configuration options for the confirmation button.
+ * @param config The `RequestConfirmationButtonConfig` object.
  * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 export function createRequestConfirmationButton(

--- a/src/components/RequestConfirmationButton.tsx
+++ b/src/components/RequestConfirmationButton.tsx
@@ -59,15 +59,6 @@ export interface RequestConfirmationButtonDefinition
  * pass this definition to createButton and provide runtime callbacks there.
  *
  * @param definition The static confirmation button settings.
- * @param definition.id Optional id carried onto buttons created from the definition.
- * @param definition.initialLabel Label for the initial button that starts the flow.
- * @param definition.confirmationMessage Optional follow-up confirmation message.
- * @param definition.confirmLabel Optional label shown on the confirm button.
- * @param definition.rejectLabel Optional label shown on the reject button.
- * @param definition.variant Optional variant for the initial button.
- * @param definition.className Optional classes applied to the initial button.
- * @param definition.style Optional inline styles applied to the initial button.
- * @param definition.onSuccess Optional callback run when the action is confirmed.
  */
 export function createRequestConfirmationButtonDef(
   definition: Omit<RequestConfirmationButtonDefinition, 'kind'>
@@ -85,15 +76,6 @@ export function createRequestConfirmationButtonDef(
  * The user can then confirm or reject the action, triggering the respective callbacks.
  *
  * @param config Configuration options for the confirmation button.
- * @param config.initialLabel Label for the initial button that starts the flow.
- * @param config.confirmationMessage Optional follow-up confirmation message.
- * @param config.confirmLabel Optional label shown on the confirm button.
- * @param config.rejectLabel Optional label shown on the reject button.
- * @param config.onConfirm Callback run when the user confirms the action.
- * @param config.onReject Callback run when the user rejects the action.
- * @param config.variant Optional variant for the initial button.
- * @param config.className Optional classes applied to the initial button.
- * @param config.style Optional inline styles applied to the initial button.
  * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 export function createRequestConfirmationButton(

--- a/src/components/RequestConfirmationButton.tsx
+++ b/src/components/RequestConfirmationButton.tsx
@@ -1,91 +1,73 @@
 import type { MessageButton, MessageButtonVariant } from '../js/types';
 import { useChatStore } from '../lib';
 
+/**
+ * Configuration for a button that asks the user to confirm or decline an action.
+ *
+ * @property initialLabel Label for the initial button that triggers the confirmation flow.
+ * @property confirmationMessage Message displayed in the followup message when the initial button is clicked.
+ * @property confirmLabel Label for the confirm button.
+ * @property rejectLabel Label for the reject button.
+ * @property onConfirm Callback function executed when the user confirms.
+ * @property onReject Callback function executed when the user rejects.
+ * @property variant Optional variant for the initial button.
+ * @property className Optional className for the initial button.
+ * @property style Optional style for the initial button.
+ */
 export interface RequestConfirmationButtonConfig {
-  /**
-   * Label for the initial button that triggers the confirmation flow.
-   */
   readonly initialLabel: string;
-
-  /**
-   * Message displayed in the followup message when the initial button is clicked.
-   */
   readonly confirmationMessage?: string | undefined;
-
-  /**
-   * Label for the confirm button. Defaults to "Confirm".
-   */
   readonly confirmLabel?: string | undefined;
-
-  /**
-   * Label for the reject button. Defaults to "Decline".
-   */
   readonly rejectLabel?: string | undefined;
-
-  /**
-   * Callback function executed when the user confirms.
-   */
   readonly onConfirm: () => void;
-
-  /**
-   * Callback function executed when the user rejects.
-   */
   readonly onReject: () => void;
-
-  /**
-   * Optional variant for the initial button. Defaults to 'default'.
-   */
   readonly variant?: MessageButtonVariant | undefined;
-
-  /**
-   * Optional className for the initial button.
-   */
   readonly className?: string | undefined;
-
-  /**
-   * Optional style for the initial button.
-   */
   readonly style?: React.CSSProperties | undefined;
 }
 
+/**
+ * Runtime overrides that can be added when building a confirmation button.
+ *
+ * @property id Optional persistent button id.
+ * @property onConfirm Callback function executed when the user confirms.
+ * @property onReject Callback function executed when the user rejects.
+ */
 export interface RequestConfirmationButtonRuntimeConfig {
-  /**
-   * Optional persistent button id. When provided, createButton can return a
-   * button that is safe to reuse in persistent button collections.
-   */
   readonly id?: string | undefined;
-
-  /**
-   * Callback function executed when the user confirms.
-   */
   readonly onConfirm?: (() => void) | undefined;
-
-  /**
-   * Callback function executed when the user rejects.
-   */
   readonly onReject?: (() => void) | undefined;
 }
 
 /**
  * Static configuration for a confirmation request button before runtime
  * callbacks are attached by the app.
+ *
+ * @property kind Discriminator used by createButton to detect this definition type.
+ * @property id Optional id used when reusing the button in persistent button collections.
+ * @property onSuccess Optional success callback attached directly to the definition.
  */
 export interface RequestConfirmationButtonDefinition
   extends Omit<RequestConfirmationButtonConfig, 'onConfirm' | 'onReject'> {
   readonly kind: 'request-confirmation';
   readonly id?: string | undefined;
-
-  /**
-   * Optional success callback attached directly to the definition. This runs
-   * when the confirmation is accepted through a button created from the
-   * definition.
-   */
   readonly onSuccess?: (() => void) | undefined;
 }
 
 /**
  * Creates a reusable definition for a confirmation request button. Apps can
  * pass this definition to createButton and provide runtime callbacks there.
+ *
+ * @param definition The static confirmation button settings.
+ * @param definition.id Optional id carried onto buttons created from the definition.
+ * @param definition.initialLabel Label for the initial button that starts the flow.
+ * @param definition.confirmationMessage Optional follow-up confirmation message.
+ * @param definition.confirmLabel Optional label shown on the confirm button.
+ * @param definition.rejectLabel Optional label shown on the reject button.
+ * @param definition.variant Optional variant for the initial button.
+ * @param definition.className Optional classes applied to the initial button.
+ * @param definition.style Optional inline styles applied to the initial button.
+ * @param definition.onSuccess Optional callback run when the action is confirmed.
  */
 export function createRequestConfirmationButtonDef(
   definition: Omit<RequestConfirmationButtonDefinition, 'kind'>
@@ -102,8 +84,17 @@ export function createRequestConfirmationButtonDef(
  * When clicked, the initial button adds a followup message with confirmation buttons.
  * The user can then confirm or reject the action, triggering the respective callbacks.
  *
- * @param config Configuration options for the confirmation button
- * @returns A MessageButton configuration that can be used in a Message's buttons array
+ * @param config Configuration options for the confirmation button.
+ * @param config.initialLabel Label for the initial button that starts the flow.
+ * @param config.confirmationMessage Optional follow-up confirmation message.
+ * @param config.confirmLabel Optional label shown on the confirm button.
+ * @param config.rejectLabel Optional label shown on the reject button.
+ * @param config.onConfirm Callback run when the user confirms the action.
+ * @param config.onReject Callback run when the user rejects the action.
+ * @param config.variant Optional variant for the initial button.
+ * @param config.className Optional classes applied to the initial button.
+ * @param config.style Optional inline styles applied to the initial button.
+ * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 export function createRequestConfirmationButton(
   config: RequestConfirmationButtonConfig

--- a/src/components/RequestConfirmationButton.tsx
+++ b/src/components/RequestConfirmationButton.tsx
@@ -1,5 +1,5 @@
-import type { MessageButton, MessageButtonVariant } from '../js/types';
-import { useChatStore } from '../lib';
+import type { MessageButton, MessageButtonVariant } from "../js/types";
+import { useChatStore } from "../lib";
 
 export interface RequestConfirmationButtonConfig {
   /**
@@ -48,6 +48,54 @@ export interface RequestConfirmationButtonConfig {
   readonly style?: React.CSSProperties | undefined;
 }
 
+export interface RequestConfirmationButtonRuntimeConfig {
+  /**
+   * Optional persistent button id. When provided, createButton can return a
+   * button that is safe to reuse in persistent button collections.
+   */
+  readonly id?: string | undefined;
+
+  /**
+   * Callback function executed when the user confirms.
+   */
+  readonly onConfirm?: (() => void) | undefined;
+
+  /**
+   * Callback function executed when the user rejects.
+   */
+  readonly onReject?: (() => void) | undefined;
+}
+
+/**
+ * Static configuration for a confirmation request button before runtime
+ * callbacks are attached by the app.
+ */
+export interface RequestConfirmationButtonDefinition
+  extends Omit<RequestConfirmationButtonConfig, "onConfirm" | "onReject"> {
+  readonly kind: "request-confirmation";
+  readonly id?: string | undefined;
+
+  /**
+   * Optional success callback attached directly to the definition. This runs
+   * when the confirmation is accepted through a button created from the
+   * definition.
+   */
+  readonly onSuccess?: (() => void) | undefined;
+}
+
+/**
+ * Creates a reusable definition for a confirmation request button. Apps can
+ * pass this definition to createButton and provide runtime callbacks there.
+ */
+export function createRequestConfirmationButtonDef(
+  definition: Omit<RequestConfirmationButtonDefinition, "kind">,
+): RequestConfirmationButtonDefinition {
+  return {
+    ...definition,
+    kind: "request-confirmation",
+  };
+}
+
 /**
  * Creates a MessageButton configuration that implements a confirmation flow.
  *
@@ -58,13 +106,13 @@ export interface RequestConfirmationButtonConfig {
  * @returns A MessageButton configuration that can be used in a Message's buttons array
  */
 export function createRequestConfirmationButton(
-  config: RequestConfirmationButtonConfig
+  config: RequestConfirmationButtonConfig,
 ): MessageButton {
   const {
     initialLabel,
     confirmationMessage,
-    confirmLabel = 'Confirm',
-    rejectLabel = 'Decline',
+    confirmLabel = "Confirm",
+    rejectLabel = "Decline",
     onConfirm,
     onReject,
     variant,
@@ -82,19 +130,19 @@ export function createRequestConfirmationButton(
 
       // Add a followup message with the confirmation message and buttons
       addMessage({
-        type: 'other',
-        content: confirmationMessage ?? 'Are you sure you want to do this?',
+        type: "other",
+        content: confirmationMessage ?? "Are you sure you want to do this?",
         buttons: [
           {
             label: confirmLabel,
-            variant: 'success',
+            variant: "success",
             onClick: () => {
               onConfirm();
             },
           },
           {
             label: rejectLabel,
-            variant: 'dull',
+            variant: "dull",
             onClick: () => {
               if (onReject) {
                 onReject();

--- a/src/components/RequestInputButton.tsx
+++ b/src/components/RequestInputButton.tsx
@@ -1,10 +1,10 @@
-import type { MessageButton, MessageButtonVariant } from '../js/types';
-import { useChatStore, usePersistentButtonStore } from '../lib';
+import type { MessageButton, MessageButtonVariant } from "../js/types";
+import { useChatStore, usePersistentButtonStore } from "../lib";
 import {
   useInputFieldStore,
   type InputType,
   type InputValidator,
-} from '../lib/inputFieldStore';
+} from "../lib/inputFieldStore";
 
 export interface RequestInputButtonConfig {
   /**
@@ -90,6 +90,66 @@ export interface RequestInputButtonConfig {
   readonly showAbort?: boolean | undefined;
 }
 
+export interface RequestInputButtonRuntimeConfig {
+  /**
+   * Optional persistent button id. When provided, createButton can return a
+   * button that is safe to reuse in persistent button collections.
+   */
+  readonly id?: string | undefined;
+
+  /**
+   * Custom callback function executed when the abort button is clicked.
+   * If not provided, the default abort behavior will be used (resets input field and clears callback).
+   */
+  readonly abortCallback?: () => void | undefined;
+
+  /**
+   * Callback function executed when the user provides invalid input.
+   * @param errorMessage The error message to display to the user
+   */
+  readonly onInvalidInput?:
+    | undefined
+    | ((inputValue: string, errorMessage: string) => void);
+
+  /**
+   * Callback function executed when the user provides valid input.
+   * @param inputValue The validated input value provided by the user
+   */
+  readonly onValidInput?: undefined | ((inputValue: string) => void);
+}
+
+/**
+ * Static configuration for an input request button before runtime callbacks
+ * are attached by the app.
+ */
+export interface RequestInputButtonDefinition
+  extends Omit<
+    RequestInputButtonConfig,
+    "abortCallback" | "onInvalidInput" | "onValidInput"
+  > {
+  readonly kind: "request-input";
+  readonly id?: string | undefined;
+
+  /**
+   * Optional success callback attached directly to the definition. This runs
+   * when valid input is submitted through a button created from the definition.
+   */
+  readonly onSuccess?: ((inputValue: string) => void) | undefined;
+}
+
+/**
+ * Creates a reusable definition for an input request button. Apps can pass
+ * this definition to createButton and provide runtime callbacks there.
+ */
+export function createRequestInputButtonDef(
+  definition: Omit<RequestInputButtonDefinition, "kind">,
+): RequestInputButtonDefinition {
+  return {
+    ...definition,
+    kind: "request-input",
+  };
+}
+
 /**
  * Creates a MessageButton configuration that implements an input request flow.
  *
@@ -100,17 +160,17 @@ export interface RequestInputButtonConfig {
  * @param config Configuration options for the input request button
  * @returns A MessageButton configuration that can be used in a Message's buttons array
  */
-const ABORT_BUTTON_ID = 'input-request-abort';
+const ABORT_BUTTON_ID = "input-request-abort";
 
 export function createRequestInputButton(
-  config: RequestInputButtonConfig
+  config: RequestInputButtonConfig,
 ): MessageButton {
   const {
     initialLabel,
     inputPromptMessage,
-    placeholder = 'Type your message...',
+    placeholder = "Type your message...",
     inputDescription,
-    inputType = 'text',
+    inputType = "text",
     validator,
     onValidInput,
     onInvalidInput,
@@ -159,7 +219,7 @@ export function createRequestInputButton(
         // Remove the abort button
         removeButton(ABORT_BUTTON_ID);
         // Reset input field stuff
-        setInputFieldValue('');
+        setInputFieldValue("");
         resetInputFieldType();
         resetInputFieldPlaceholder();
         resetInputFieldDescription();
@@ -192,7 +252,7 @@ export function createRequestInputButton(
           const messages = getMessages();
           const lastSelfMessage = [...messages]
             .reverse()
-            .find(msg => msg.type === 'self');
+            .find((msg) => msg.type === "self");
           if (lastSelfMessage) {
             const inputValue = lastSelfMessage.rawContent;
 
@@ -206,9 +266,9 @@ export function createRequestInputButton(
               } else {
                 isValid = false;
                 errorMessage =
-                  typeof validationResult === 'string'
+                  typeof validationResult === "string"
                     ? validationResult
-                    : 'Invalid input. Please try again.';
+                    : "Invalid input. Please try again.";
               }
             }
 
@@ -221,7 +281,7 @@ export function createRequestInputButton(
             } else {
               onInvalidInput?.(
                 inputValue,
-                errorMessage ?? 'Invalid input. Please try again.'
+                errorMessage ?? "Invalid input. Please try again.",
               );
 
               if (!suppressValidationFailureMessage) {
@@ -229,16 +289,16 @@ export function createRequestInputButton(
                 // so the self can try again. The abort button will be cleared by addMessage,
                 // so we need to re-add it.
                 addMessageCallback({
-                  type: 'other',
-                  content: errorMessage ?? 'Invalid input. Please try again.',
+                  type: "other",
+                  content: errorMessage ?? "Invalid input. Please try again.",
                   userResponseCallback: createValidationCallback(),
                 });
                 // Re-add abort button after error message since addMessage clears it
                 if (showAbort) {
                   addButton({
                     id: ABORT_BUTTON_ID,
-                    label: abortLabel ?? 'Abort',
-                    variant: 'error',
+                    label: abortLabel ?? "Abort",
+                    variant: "error",
                     onClick: handleAbort,
                   });
                 }
@@ -250,7 +310,7 @@ export function createRequestInputButton(
 
       // Add a message prompting for input with userResponseCallback to capture the input
       addMessage({
-        type: 'other',
+        type: "other",
         content: inputPromptMessage,
         userResponseCallback: createValidationCallback(),
       });
@@ -260,8 +320,8 @@ export function createRequestInputButton(
       if (showAbort) {
         addButton({
           id: ABORT_BUTTON_ID,
-          label: abortLabel ?? 'Abort',
-          variant: 'error',
+          label: abortLabel ?? "Abort",
+          variant: "error",
           onClick: handleAbort,
         });
       }

--- a/src/components/RequestInputButton.tsx
+++ b/src/components/RequestInputButton.tsx
@@ -85,20 +85,6 @@ export interface RequestInputButtonDefinition
  * this definition to createButton and provide runtime callbacks there.
  *
  * @param definition The static input-request button settings.
- * @param definition.id Optional id carried onto buttons created from the definition.
- * @param definition.initialLabel Label for the initial button that starts the flow.
- * @param definition.inputPromptMessage Message shown when requesting input from the user.
- * @param definition.placeholder Optional placeholder shown in the input field.
- * @param definition.inputDescription Optional helper text shown above the input field.
- * @param definition.inputType Optional input type used for the shared input field.
- * @param definition.validator Optional validator used to accept or reject submitted input.
- * @param definition.suppressValidationFailureMessage When true, skips the default validation error message.
- * @param definition.variant Optional variant for the initial button.
- * @param definition.className Optional classes applied to the initial button.
- * @param definition.style Optional inline styles applied to the initial button.
- * @param definition.abortLabel Optional label shown on the abort button.
- * @param definition.showAbort Whether to show the abort button during the flow.
- * @param definition.onSuccess Optional callback run after valid input is submitted.
  */
 export function createRequestInputButtonDef(
   definition: Omit<RequestInputButtonDefinition, 'kind'>
@@ -117,21 +103,6 @@ export function createRequestInputButtonDef(
  * Once the user provides valid input, the onInput callback is executed.
  *
  * @param config Configuration options for the input request button.
- * @param config.initialLabel Label for the initial button that starts the flow.
- * @param config.inputPromptMessage Message shown when requesting input from the user.
- * @param config.placeholder Optional placeholder shown in the input field.
- * @param config.inputDescription Optional helper text shown above the input field.
- * @param config.inputType Optional input type used for the shared input field.
- * @param config.validator Optional validator used to accept or reject submitted input.
- * @param config.onInvalidInput Optional callback run when submitted input is rejected.
- * @param config.onValidInput Optional callback run when submitted input is accepted.
- * @param config.suppressValidationFailureMessage When true, skips the default validation error message.
- * @param config.variant Optional variant for the initial button.
- * @param config.className Optional classes applied to the initial button.
- * @param config.style Optional inline styles applied to the initial button.
- * @param config.abortLabel Optional label shown on the abort button.
- * @param config.abortCallback Optional custom abort handler.
- * @param config.showAbort Whether to show the abort button during the flow.
  * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 const ABORT_BUTTON_ID = 'input-request-abort';

--- a/src/components/RequestInputButton.tsx
+++ b/src/components/RequestInputButton.tsx
@@ -84,7 +84,7 @@ export interface RequestInputButtonDefinition
  * Creates a reusable definition for an input request button. Apps can pass
  * this definition to createButton and provide runtime callbacks there.
  *
- * @param definition The static input-request button settings.
+ * @param definition The `Omit<RequestInputButtonDefinition, 'kind'>` object.
  */
 export function createRequestInputButtonDef(
   definition: Omit<RequestInputButtonDefinition, 'kind'>
@@ -102,7 +102,7 @@ export function createRequestInputButtonDef(
  * the input field with the specified type, placeholder, description, and validator.
  * Once the user provides valid input, the onInput callback is executed.
  *
- * @param config Configuration options for the input request button.
+ * @param config The `RequestInputButtonConfig` object.
  * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 const ABORT_BUTTON_ID = 'input-request-abort';

--- a/src/components/RequestInputButton.tsx
+++ b/src/components/RequestInputButton.tsx
@@ -1,10 +1,10 @@
-import type { MessageButton, MessageButtonVariant } from "../js/types";
-import { useChatStore, usePersistentButtonStore } from "../lib";
+import type { MessageButton, MessageButtonVariant } from '../js/types';
+import { useChatStore, usePersistentButtonStore } from '../lib';
 import {
   useInputFieldStore,
   type InputType,
   type InputValidator,
-} from "../lib/inputFieldStore";
+} from '../lib/inputFieldStore';
 
 export interface RequestInputButtonConfig {
   /**
@@ -125,9 +125,9 @@ export interface RequestInputButtonRuntimeConfig {
 export interface RequestInputButtonDefinition
   extends Omit<
     RequestInputButtonConfig,
-    "abortCallback" | "onInvalidInput" | "onValidInput"
+    'abortCallback' | 'onInvalidInput' | 'onValidInput'
   > {
-  readonly kind: "request-input";
+  readonly kind: 'request-input';
   readonly id?: string | undefined;
 
   /**
@@ -142,11 +142,11 @@ export interface RequestInputButtonDefinition
  * this definition to createButton and provide runtime callbacks there.
  */
 export function createRequestInputButtonDef(
-  definition: Omit<RequestInputButtonDefinition, "kind">,
+  definition: Omit<RequestInputButtonDefinition, 'kind'>
 ): RequestInputButtonDefinition {
   return {
     ...definition,
-    kind: "request-input",
+    kind: 'request-input',
   };
 }
 
@@ -160,17 +160,17 @@ export function createRequestInputButtonDef(
  * @param config Configuration options for the input request button
  * @returns A MessageButton configuration that can be used in a Message's buttons array
  */
-const ABORT_BUTTON_ID = "input-request-abort";
+const ABORT_BUTTON_ID = 'input-request-abort';
 
 export function createRequestInputButton(
-  config: RequestInputButtonConfig,
+  config: RequestInputButtonConfig
 ): MessageButton {
   const {
     initialLabel,
     inputPromptMessage,
-    placeholder = "Type your message...",
+    placeholder = 'Type your message...',
     inputDescription,
-    inputType = "text",
+    inputType = 'text',
     validator,
     onValidInput,
     onInvalidInput,
@@ -219,7 +219,7 @@ export function createRequestInputButton(
         // Remove the abort button
         removeButton(ABORT_BUTTON_ID);
         // Reset input field stuff
-        setInputFieldValue("");
+        setInputFieldValue('');
         resetInputFieldType();
         resetInputFieldPlaceholder();
         resetInputFieldDescription();
@@ -252,7 +252,7 @@ export function createRequestInputButton(
           const messages = getMessages();
           const lastSelfMessage = [...messages]
             .reverse()
-            .find((msg) => msg.type === "self");
+            .find(msg => msg.type === 'self');
           if (lastSelfMessage) {
             const inputValue = lastSelfMessage.rawContent;
 
@@ -266,9 +266,9 @@ export function createRequestInputButton(
               } else {
                 isValid = false;
                 errorMessage =
-                  typeof validationResult === "string"
+                  typeof validationResult === 'string'
                     ? validationResult
-                    : "Invalid input. Please try again.";
+                    : 'Invalid input. Please try again.';
               }
             }
 
@@ -281,7 +281,7 @@ export function createRequestInputButton(
             } else {
               onInvalidInput?.(
                 inputValue,
-                errorMessage ?? "Invalid input. Please try again.",
+                errorMessage ?? 'Invalid input. Please try again.'
               );
 
               if (!suppressValidationFailureMessage) {
@@ -289,16 +289,16 @@ export function createRequestInputButton(
                 // so the self can try again. The abort button will be cleared by addMessage,
                 // so we need to re-add it.
                 addMessageCallback({
-                  type: "other",
-                  content: errorMessage ?? "Invalid input. Please try again.",
+                  type: 'other',
+                  content: errorMessage ?? 'Invalid input. Please try again.',
                   userResponseCallback: createValidationCallback(),
                 });
                 // Re-add abort button after error message since addMessage clears it
                 if (showAbort) {
                   addButton({
                     id: ABORT_BUTTON_ID,
-                    label: abortLabel ?? "Abort",
-                    variant: "error",
+                    label: abortLabel ?? 'Abort',
+                    variant: 'error',
                     onClick: handleAbort,
                   });
                 }
@@ -310,7 +310,7 @@ export function createRequestInputButton(
 
       // Add a message prompting for input with userResponseCallback to capture the input
       addMessage({
-        type: "other",
+        type: 'other',
         content: inputPromptMessage,
         userResponseCallback: createValidationCallback(),
       });
@@ -320,8 +320,8 @@ export function createRequestInputButton(
       if (showAbort) {
         addButton({
           id: ABORT_BUTTON_ID,
-          label: abortLabel ?? "Abort",
-          variant: "error",
+          label: abortLabel ?? 'Abort',
+          variant: 'error',
           onClick: handleAbort,
         });
       }

--- a/src/components/RequestInputButton.tsx
+++ b/src/components/RequestInputButton.tsx
@@ -6,121 +6,69 @@ import {
   type InputValidator,
 } from '../lib/inputFieldStore';
 
+/**
+ * Configuration for a button that asks the user to submit a follow-up input.
+ *
+ * @property initialLabel Label for the initial button that triggers the input request flow.
+ * @property inputPromptMessage Message displayed when requesting input from the user.
+ * @property placeholder Placeholder text for the input field.
+ * @property inputDescription Description text shown above the input field.
+ * @property inputType Type of input field used for the request flow.
+ * @property validator Validation function used to accept or reject submitted input.
+ * @property onInvalidInput Callback function executed when the user provides invalid input.
+ * @property onValidInput Callback function executed when the user provides valid input.
+ * @property suppressValidationFailureMessage When true, skips the default validation failure message.
+ * @property variant Optional variant for the initial button.
+ * @property className Optional className for the initial button.
+ * @property style Optional style for the initial button.
+ * @property abortLabel Custom label for the abort button.
+ * @property abortCallback Custom callback function executed when the abort button is clicked.
+ * @property showAbort Whether to show the abort button during the flow.
+ */
 export interface RequestInputButtonConfig {
-  /**
-   * Label for the initial button that triggers the input request flow.
-   */
   readonly initialLabel: string;
-
-  /**
-   * Message displayed when requesting input from the user.
-   */
   readonly inputPromptMessage: string;
-
-  /**
-   * Placeholder text for the input field. Defaults to "Type your message...".
-   */
   readonly placeholder?: string | undefined;
-
-  /**
-   * Description text shown above the input field. Optional.
-   */
   readonly inputDescription?: string | undefined;
-
-  /**
-   * Type of input field (text, password, email, etc.). Defaults to 'text'.
-   */
   readonly inputType?: InputType | undefined;
-
-  /**
-   * Validation function for the input. Returns true if valid, or an error message string if invalid.
-   * If validation fails, the input will not be processed.
-   */
   readonly validator?: InputValidator | undefined;
-
-  /**
-   * Callback function executed when the user provides invalid input.
-   * @param errorMessage The error message to display to the user
-   */
   readonly onInvalidInput?:
     | undefined
     | ((inputValue: string, errorMessage: string) => void);
-
-  /**
-   * Callback function executed when the user provides valid input.
-   * @param inputValue The validated input value provided by the user
-   */
   readonly onValidInput?: undefined | ((inputValue: string) => void);
-
-  /**
-   * If true, suppress the default validation failure message. Defaults to false.
-   * When enabled, only the onInvalidInput callback will be triggered with the validation result.
-   */
   readonly suppressValidationFailureMessage?: boolean | undefined;
-
-  /**
-   * Optional variant for the initial button. Defaults to 'default'.
-   */
   readonly variant?: MessageButtonVariant | undefined;
-
-  /**
-   * Optional className for the initial button.
-   */
   readonly className?: string | undefined;
-
-  /**
-   * Optional style for the initial button.
-   */
   readonly style?: React.CSSProperties | undefined;
-
-  /**
-   * Custom label for the abort button. Defaults to 'Abort'.
-   */
   readonly abortLabel?: string | undefined;
-
-  /**
-   * Custom callback function executed when the abort button is clicked.
-   * If not provided, the default abort behavior will be used (resets input field and clears callback).
-   */
   readonly abortCallback?: () => void | undefined;
-
-  /**
-   * Whether to show the abort button. Defaults to true.
-   */
   readonly showAbort?: boolean | undefined;
 }
 
+/**
+ * Runtime overrides that can be added when building an input request button.
+ *
+ * @property id Optional persistent button id.
+ * @property abortCallback Custom callback function executed when the abort button is clicked.
+ * @property onInvalidInput Callback function executed when the user provides invalid input.
+ * @property onValidInput Callback function executed when the user provides valid input.
+ */
 export interface RequestInputButtonRuntimeConfig {
-  /**
-   * Optional persistent button id. When provided, createButton can return a
-   * button that is safe to reuse in persistent button collections.
-   */
   readonly id?: string | undefined;
-
-  /**
-   * Custom callback function executed when the abort button is clicked.
-   * If not provided, the default abort behavior will be used (resets input field and clears callback).
-   */
   readonly abortCallback?: () => void | undefined;
-
-  /**
-   * Callback function executed when the user provides invalid input.
-   * @param errorMessage The error message to display to the user
-   */
   readonly onInvalidInput?:
     | undefined
     | ((inputValue: string, errorMessage: string) => void);
-
-  /**
-   * Callback function executed when the user provides valid input.
-   * @param inputValue The validated input value provided by the user
-   */
   readonly onValidInput?: undefined | ((inputValue: string) => void);
 }
 
 /**
  * Static configuration for an input request button before runtime callbacks
  * are attached by the app.
+ *
+ * @property kind Discriminator used by createButton to detect this definition type.
+ * @property id Optional id used when reusing the button in persistent button collections.
+ * @property onSuccess Optional success callback attached directly to the definition.
  */
 export interface RequestInputButtonDefinition
   extends Omit<
@@ -129,17 +77,28 @@ export interface RequestInputButtonDefinition
   > {
   readonly kind: 'request-input';
   readonly id?: string | undefined;
-
-  /**
-   * Optional success callback attached directly to the definition. This runs
-   * when valid input is submitted through a button created from the definition.
-   */
   readonly onSuccess?: ((inputValue: string) => void) | undefined;
 }
 
 /**
  * Creates a reusable definition for an input request button. Apps can pass
  * this definition to createButton and provide runtime callbacks there.
+ *
+ * @param definition The static input-request button settings.
+ * @param definition.id Optional id carried onto buttons created from the definition.
+ * @param definition.initialLabel Label for the initial button that starts the flow.
+ * @param definition.inputPromptMessage Message shown when requesting input from the user.
+ * @param definition.placeholder Optional placeholder shown in the input field.
+ * @param definition.inputDescription Optional helper text shown above the input field.
+ * @param definition.inputType Optional input type used for the shared input field.
+ * @param definition.validator Optional validator used to accept or reject submitted input.
+ * @param definition.suppressValidationFailureMessage When true, skips the default validation error message.
+ * @param definition.variant Optional variant for the initial button.
+ * @param definition.className Optional classes applied to the initial button.
+ * @param definition.style Optional inline styles applied to the initial button.
+ * @param definition.abortLabel Optional label shown on the abort button.
+ * @param definition.showAbort Whether to show the abort button during the flow.
+ * @param definition.onSuccess Optional callback run after valid input is submitted.
  */
 export function createRequestInputButtonDef(
   definition: Omit<RequestInputButtonDefinition, 'kind'>
@@ -157,8 +116,23 @@ export function createRequestInputButtonDef(
  * the input field with the specified type, placeholder, description, and validator.
  * Once the user provides valid input, the onInput callback is executed.
  *
- * @param config Configuration options for the input request button
- * @returns A MessageButton configuration that can be used in a Message's buttons array
+ * @param config Configuration options for the input request button.
+ * @param config.initialLabel Label for the initial button that starts the flow.
+ * @param config.inputPromptMessage Message shown when requesting input from the user.
+ * @param config.placeholder Optional placeholder shown in the input field.
+ * @param config.inputDescription Optional helper text shown above the input field.
+ * @param config.inputType Optional input type used for the shared input field.
+ * @param config.validator Optional validator used to accept or reject submitted input.
+ * @param config.onInvalidInput Optional callback run when submitted input is rejected.
+ * @param config.onValidInput Optional callback run when submitted input is accepted.
+ * @param config.suppressValidationFailureMessage When true, skips the default validation error message.
+ * @param config.variant Optional variant for the initial button.
+ * @param config.className Optional classes applied to the initial button.
+ * @param config.style Optional inline styles applied to the initial button.
+ * @param config.abortLabel Optional label shown on the abort button.
+ * @param config.abortCallback Optional custom abort handler.
+ * @param config.showAbort Whether to show the abort button during the flow.
+ * @returns A MessageButton configuration that can be used in a Message's buttons array.
  */
 const ABORT_BUTTON_ID = 'input-request-abort';
 

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -15,21 +15,19 @@ import {
 /**
  * Base configuration for a plain message button definition.
  *
- * @property id Optional id used when reusing the button in persistent button collections.
+ * @property id Optional id used when reusing the button in persistent button collections. Can be either defined in the definition or in the runtime config.
  */
-export interface ButtonDefinition extends Omit<MessageButton, 'onClick'> {
+export interface ButtonDefinition extends MessageButton {
   readonly id?: string | undefined;
 }
 
 /**
  * Runtime overrides that can be applied when creating a plain message button.
  *
- * @property id Optional id that overrides the definition id when the button is created.
- * @property onClick Click handler attached to the created button at runtime.
+ * @property id Optional id that overrides the definition id when the button is created. Can be either defined in the definition or in the runtime config.
  */
 export interface ButtonRuntimeConfig {
   readonly id?: string | undefined;
-  readonly onClick?: (() => void) | undefined;
 }
 
 /**
@@ -156,10 +154,9 @@ export function createButton(
   }
 
   const { id: _definitionId, ...restDefinition } = definition;
-  const { id: _runtimeId, onClick } = runtimeConfig as ButtonRuntimeConfig;
+  const { id: _runtimeId } = runtimeConfig as ButtonRuntimeConfig;
   const button: MessageButton = {
     ...restDefinition,
-    ...(onClick ? { onClick } : {}),
   };
 
   return withOptionalId(button, id);

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -12,20 +12,39 @@ import {
   type RequestInputButtonRuntimeConfig,
 } from './RequestInputButton';
 
+/**
+ * Base configuration for a plain message button definition.
+ *
+ * @property id Optional id used when reusing the button in persistent button collections.
+ */
 export interface ButtonDefinition extends Omit<MessageButton, 'onClick'> {
   readonly id?: string | undefined;
 }
 
+/**
+ * Runtime overrides that can be applied when creating a plain message button.
+ *
+ * @property id Optional id that overrides the definition id when the button is created.
+ * @property onClick Click handler attached to the created button at runtime.
+ */
 export interface ButtonRuntimeConfig {
   readonly id?: string | undefined;
   readonly onClick?: (() => void) | undefined;
 }
 
+/**
+ * Union of all button definition shapes supported by createButton.
+ */
 export type AnyButtonDefinition =
   | ButtonDefinition
   | RequestInputButtonDefinition
   | RequestConfirmationButtonDefinition;
 
+/**
+ * Final button shape returned by createButton.
+ *
+ * @property id Optional id used when storing the button in persistent button collections.
+ */
 export type CreatedButton = MessageButton & {
   readonly id?: string | undefined;
 };
@@ -56,6 +75,14 @@ function isRequestConfirmationButtonDefinition(
   return 'kind' in definition && definition.kind === 'request-confirmation';
 }
 
+/**
+ * Creates a plain, input-request, or confirmation button from a shared API.
+ *
+ * @param definition The button definition to turn into a clickable message button.
+ * @param definition.id Optional id carried onto the created button.
+ * @param runtimeConfig Optional runtime overrides applied when the button is created.
+ * @param runtimeConfig.id Optional id that overrides the definition id.
+ */
 export function createButton(
   definition: ButtonDefinition,
   runtimeConfig?: ButtonRuntimeConfig
@@ -68,6 +95,14 @@ export function createButton(
   definition: RequestConfirmationButtonDefinition,
   runtimeConfig?: RequestConfirmationButtonRuntimeConfig
 ): CreatedButton;
+/**
+ * Creates a plain, input-request, or confirmation button from a shared API.
+ *
+ * @param definition The button definition to turn into a clickable message button.
+ * @param definition.id Optional id carried onto the created button.
+ * @param runtimeConfig Optional runtime overrides applied when the button is created.
+ * @param runtimeConfig.id Optional id that overrides the definition id.
+ */
 export function createButton(
   definition: AnyButtonDefinition,
   runtimeConfig:

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -79,9 +79,7 @@ function isRequestConfirmationButtonDefinition(
  * Creates a plain, input-request, or confirmation button from a shared API.
  *
  * @param definition The button definition to turn into a clickable message button.
- * @param definition.id Optional id carried onto the created button.
  * @param runtimeConfig Optional runtime overrides applied when the button is created.
- * @param runtimeConfig.id Optional id that overrides the definition id.
  */
 export function createButton(
   definition: ButtonDefinition,
@@ -99,9 +97,7 @@ export function createButton(
  * Creates a plain, input-request, or confirmation button from a shared API.
  *
  * @param definition The button definition to turn into a clickable message button.
- * @param definition.id Optional id carried onto the created button.
  * @param runtimeConfig Optional runtime overrides applied when the button is created.
- * @param runtimeConfig.id Optional id that overrides the definition id.
  */
 export function createButton(
   definition: AnyButtonDefinition,

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -1,0 +1,135 @@
+import type { MessageButton } from "../js/types";
+import {
+  createRequestConfirmationButton,
+  type RequestConfirmationButtonConfig,
+  type RequestConfirmationButtonDefinition,
+  type RequestConfirmationButtonRuntimeConfig,
+} from "./RequestConfirmationButton";
+import {
+  createRequestInputButton,
+  type RequestInputButtonConfig,
+  type RequestInputButtonDefinition,
+  type RequestInputButtonRuntimeConfig,
+} from "./RequestInputButton";
+
+export interface ButtonDefinition extends Omit<MessageButton, "onClick"> {
+  readonly id?: string | undefined;
+}
+
+export interface ButtonRuntimeConfig {
+  readonly id?: string | undefined;
+  readonly onClick?: (() => void) | undefined;
+}
+
+export type AnyButtonDefinition =
+  | ButtonDefinition
+  | RequestInputButtonDefinition
+  | RequestConfirmationButtonDefinition;
+
+export type CreatedButton = MessageButton & {
+  readonly id?: string | undefined;
+};
+
+function withOptionalId(
+  button: MessageButton,
+  id: string | undefined,
+): CreatedButton {
+  if (!id) {
+    return button;
+  }
+
+  return {
+    ...button,
+    id,
+  };
+}
+
+function isRequestInputButtonDefinition(
+  definition: AnyButtonDefinition,
+): definition is RequestInputButtonDefinition {
+  return "kind" in definition && definition.kind === "request-input";
+}
+
+function isRequestConfirmationButtonDefinition(
+  definition: AnyButtonDefinition,
+): definition is RequestConfirmationButtonDefinition {
+  return "kind" in definition && definition.kind === "request-confirmation";
+}
+
+export function createButton(
+  definition: ButtonDefinition,
+  runtimeConfig?: ButtonRuntimeConfig,
+): CreatedButton;
+export function createButton(
+  definition: RequestInputButtonDefinition,
+  runtimeConfig?: RequestInputButtonRuntimeConfig,
+): CreatedButton;
+export function createButton(
+  definition: RequestConfirmationButtonDefinition,
+  runtimeConfig?: RequestConfirmationButtonRuntimeConfig,
+): CreatedButton;
+export function createButton(
+  definition: AnyButtonDefinition,
+  runtimeConfig:
+    | ButtonRuntimeConfig
+    | RequestInputButtonRuntimeConfig
+    | RequestConfirmationButtonRuntimeConfig = {},
+): CreatedButton {
+  const id = runtimeConfig.id ?? definition.id;
+
+  if (isRequestInputButtonDefinition(definition)) {
+    const {
+      id: _definitionId,
+      kind: _kind,
+      onSuccess,
+      ...restDefinition
+    } = definition;
+    const { id: _runtimeId, ...restRuntime } =
+      runtimeConfig as RequestInputButtonRuntimeConfig;
+    const handleValidInput = (inputValue: string): void => {
+      onSuccess?.(inputValue);
+      restRuntime.onValidInput?.(inputValue);
+    };
+    const buttonConfig: RequestInputButtonConfig = {
+      ...restDefinition,
+      ...restRuntime,
+      ...(onSuccess || restRuntime.onValidInput
+        ? { onValidInput: handleValidInput }
+        : {}),
+    };
+
+    return withOptionalId(createRequestInputButton(buttonConfig), id);
+  }
+
+  if (isRequestConfirmationButtonDefinition(definition)) {
+    const {
+      id: _definitionId,
+      kind: _kind,
+      onSuccess,
+      ...restDefinition
+    } = definition;
+    const { id: _runtimeId, ...restRuntime } =
+      runtimeConfig as RequestConfirmationButtonRuntimeConfig;
+    const handleConfirm = (): void => {
+      onSuccess?.();
+      restRuntime.onConfirm?.();
+    };
+    const buttonConfig: RequestConfirmationButtonConfig = {
+      ...restDefinition,
+      ...restRuntime,
+      onConfirm: handleConfirm,
+      onReject: restRuntime.onReject ?? (() => {}),
+    };
+
+    return withOptionalId(createRequestConfirmationButton(buttonConfig), id);
+  }
+
+  const { id: _definitionId, ...restDefinition } = definition;
+  const { id: _runtimeId, onClick } = runtimeConfig as ButtonRuntimeConfig;
+  const button: MessageButton = {
+    ...restDefinition,
+    ...(onClick ? { onClick } : {}),
+  };
+
+  return withOptionalId(button, id);
+}

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -1,18 +1,18 @@
-import type { MessageButton } from "../js/types";
+import type { MessageButton } from '../js/types';
 import {
   createRequestConfirmationButton,
   type RequestConfirmationButtonConfig,
   type RequestConfirmationButtonDefinition,
   type RequestConfirmationButtonRuntimeConfig,
-} from "./RequestConfirmationButton";
+} from './RequestConfirmationButton';
 import {
   createRequestInputButton,
   type RequestInputButtonConfig,
   type RequestInputButtonDefinition,
   type RequestInputButtonRuntimeConfig,
-} from "./RequestInputButton";
+} from './RequestInputButton';
 
-export interface ButtonDefinition extends Omit<MessageButton, "onClick"> {
+export interface ButtonDefinition extends Omit<MessageButton, 'onClick'> {
   readonly id?: string | undefined;
 }
 
@@ -32,7 +32,7 @@ export type CreatedButton = MessageButton & {
 
 function withOptionalId(
   button: MessageButton,
-  id: string | undefined,
+  id: string | undefined
 ): CreatedButton {
   if (!id) {
     return button;
@@ -45,35 +45,35 @@ function withOptionalId(
 }
 
 function isRequestInputButtonDefinition(
-  definition: AnyButtonDefinition,
+  definition: AnyButtonDefinition
 ): definition is RequestInputButtonDefinition {
-  return "kind" in definition && definition.kind === "request-input";
+  return 'kind' in definition && definition.kind === 'request-input';
 }
 
 function isRequestConfirmationButtonDefinition(
-  definition: AnyButtonDefinition,
+  definition: AnyButtonDefinition
 ): definition is RequestConfirmationButtonDefinition {
-  return "kind" in definition && definition.kind === "request-confirmation";
+  return 'kind' in definition && definition.kind === 'request-confirmation';
 }
 
 export function createButton(
   definition: ButtonDefinition,
-  runtimeConfig?: ButtonRuntimeConfig,
+  runtimeConfig?: ButtonRuntimeConfig
 ): CreatedButton;
 export function createButton(
   definition: RequestInputButtonDefinition,
-  runtimeConfig?: RequestInputButtonRuntimeConfig,
+  runtimeConfig?: RequestInputButtonRuntimeConfig
 ): CreatedButton;
 export function createButton(
   definition: RequestConfirmationButtonDefinition,
-  runtimeConfig?: RequestConfirmationButtonRuntimeConfig,
+  runtimeConfig?: RequestConfirmationButtonRuntimeConfig
 ): CreatedButton;
 export function createButton(
   definition: AnyButtonDefinition,
   runtimeConfig:
     | ButtonRuntimeConfig
     | RequestInputButtonRuntimeConfig
-    | RequestConfirmationButtonRuntimeConfig = {},
+    | RequestConfirmationButtonRuntimeConfig = {}
 ): CreatedButton {
   const id = runtimeConfig.id ?? definition.id;
 

--- a/src/components/createButton.ts
+++ b/src/components/createButton.ts
@@ -76,8 +76,8 @@ function isRequestConfirmationButtonDefinition(
 /**
  * Creates a plain, input-request, or confirmation button from a shared API.
  *
- * @param definition The button definition to turn into a clickable message button.
- * @param runtimeConfig Optional runtime overrides applied when the button is created.
+ * @param definition The `ButtonDefinition` object.
+ * @param runtimeConfig The optional `ButtonRuntimeConfig` object.
  */
 export function createButton(
   definition: ButtonDefinition,
@@ -94,8 +94,8 @@ export function createButton(
 /**
  * Creates a plain, input-request, or confirmation button from a shared API.
  *
- * @param definition The button definition to turn into a clickable message button.
- * @param runtimeConfig Optional runtime overrides applied when the button is created.
+ * @param definition The `AnyButtonDefinition` object.
+ * @param runtimeConfig The optional `ButtonRuntimeConfig | RequestInputButtonRuntimeConfig | RequestConfirmationButtonRuntimeConfig` object.
  */
 export function createButton(
   definition: AnyButtonDefinition,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,24 +1,24 @@
-export { Chat } from "./Chat";
-export { MessageBubble } from "./MessageBubble";
-export { MessageButtons } from "./MessageButtons";
-export { MessagesList } from "./MessagesList";
-export { LoadingIndicator } from "./LoadingIndicator";
-export { ChatInput } from "./ChatInput";
-export { PersistentButtons } from "./PersistentButtons";
+export { Chat } from './Chat';
+export { MessageBubble } from './MessageBubble';
+export { MessageButtons } from './MessageButtons';
+export { MessagesList } from './MessagesList';
+export { LoadingIndicator } from './LoadingIndicator';
+export { ChatInput } from './ChatInput';
+export { PersistentButtons } from './PersistentButtons';
 export {
   createButton,
   type AnyButtonDefinition,
   type ButtonDefinition,
   type ButtonRuntimeConfig,
   type CreatedButton,
-} from "./createButton";
+} from './createButton';
 export {
   createRequestConfirmationButtonDef,
   type RequestConfirmationButtonDefinition,
   type RequestConfirmationButtonRuntimeConfig,
-} from "./RequestConfirmationButton";
+} from './RequestConfirmationButton';
 export {
   createRequestInputButtonDef,
   type RequestInputButtonDefinition,
   type RequestInputButtonRuntimeConfig,
-} from "./RequestInputButton";
+} from './RequestInputButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,14 +1,24 @@
-export { Chat } from './Chat';
-export { MessageBubble } from './MessageBubble';
-export { MessageButtons } from './MessageButtons';
-export { MessagesList } from './MessagesList';
-export { ChatInput } from './ChatInput';
-export { PersistentButtons } from './PersistentButtons';
+export { Chat } from "./Chat";
+export { MessageBubble } from "./MessageBubble";
+export { MessageButtons } from "./MessageButtons";
+export { MessagesList } from "./MessagesList";
+export { LoadingIndicator } from "./LoadingIndicator";
+export { ChatInput } from "./ChatInput";
+export { PersistentButtons } from "./PersistentButtons";
 export {
-  createRequestConfirmationButton,
-  type RequestConfirmationButtonConfig,
-} from './RequestConfirmationButton';
+  createButton,
+  type AnyButtonDefinition,
+  type ButtonDefinition,
+  type ButtonRuntimeConfig,
+  type CreatedButton,
+} from "./createButton";
 export {
-  createRequestInputButton,
-  type RequestInputButtonConfig,
-} from './RequestInputButton';
+  createRequestConfirmationButtonDef,
+  type RequestConfirmationButtonDefinition,
+  type RequestConfirmationButtonRuntimeConfig,
+} from "./RequestConfirmationButton";
+export {
+  createRequestInputButtonDef,
+  type RequestInputButtonDefinition,
+  type RequestInputButtonRuntimeConfig,
+} from "./RequestInputButton";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -35,11 +35,18 @@ const buttonVariants = cva(
 /**
  * Shared button props that combine native button attributes with supported
  * visual variants.
+ *
+ * @property variant Optional visual variant for the button.
+ * @property size Optional size variant for the button.
+ * @property className Optional classes merged into the button styles.
  */
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {}
 
+/**
+ * Shared button primitive used across the chat UI.
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, ...props }, ref) => {
     return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -32,6 +32,10 @@ const buttonVariants = cva(
   }
 );
 
+/**
+ * Shared button props that combine native button attributes with supported
+ * visual variants.
+ */
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // Main entry point - export everything from components and lib
-export * from "./components";
-export * from "./lib";
-export * from "./js/types";
+export * from './components';
+export * from './lib';
+export * from './js/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // Main entry point - export everything from components and lib
-export * from './components';
-export * from './lib';
-export * from './js/types';
+export * from "./components";
+export * from "./lib";
+export * from "./js/types";

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -70,6 +70,8 @@ export interface InputMessage {
   readonly content: string;
   readonly rawContent?: string;
   readonly timestamp?: Date;
+  readonly isLoading?: boolean;
+  readonly loadingLabel?: string;
   readonly userResponseCallback?: () => void;
   readonly buttons?: readonly MessageButton[];
 }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -1,17 +1,20 @@
+/**
+ * Indicates whether a message is from the local user or the assistant side.
+ */
 export type MessageType = 'self' | 'other';
 
 /**
  * Theme configuration for the chat component.
  *
- * @property primaryColor Color for self messages and primary elements
- * @property secondaryColor Color for other messages and secondary elements
- * @property backgroundColor Background color of the chat container
- * @property textColor Primary text color
- * @property borderColor Color for borders and dividers
- * @property inputBackgroundColor Background color for the input field
- * @property inputTextColor Text color for the input field
- * @property buttonColor Background color for buttons
- * @property buttonTextColor Text color for buttons
+ * @property primaryColor Color used for self messages and other primary surfaces.
+ * @property secondaryColor Color used for assistant messages and secondary surfaces.
+ * @property backgroundColor Background color of the chat container.
+ * @property textColor Primary text color used across the chat UI.
+ * @property borderColor Color used for borders and separators.
+ * @property inputBackgroundColor Background color of the shared input field.
+ * @property inputTextColor Text color used inside the shared input field.
+ * @property buttonColor Background color used for primary buttons.
+ * @property buttonTextColor Text color used on buttons.
  */
 export interface ChatTheme {
   readonly primaryColor?: string;
@@ -39,11 +42,11 @@ export type MessageButtonVariant =
 /**
  * Represents a button associated with a message.
  *
- * @property label The text displayed on the button.
- * @property onClick Callback function executed when the button is clicked.
- * @property variant Optional variant style for the button. Defaults to 'default'.
- * @property className Optional custom CSS class names to apply to the button.
- * @property style Optional custom inline styles to apply to the button. These will override variant styles.
+ * @property label Text shown on the button.
+ * @property onClick Runs when the button is clicked.
+ * @property variant Visual variant used to style the button.
+ * @property className Optional CSS classes applied to the button.
+ * @property style Optional inline styles that override the variant styles.
  */
 export interface MessageButton {
   readonly label: string;
@@ -56,13 +59,15 @@ export interface MessageButton {
 /**
  * Represents a single chat message.
  *
- * @property id Unique identifier for the message.
- * @property type Indicates whether the message is from 'self' or 'other'.
- * @property content The textual content of the message to be displayed to the user.
- * @property rawContent The raw content of the message, used for processing and validation.
- * @property timestamp The date and time the message was created.
- * @property userResponseCallback Optional callback function invoked when a self response is received right after this message.
- * @property buttons Optional array of buttons to display below the message.
+ * @property id Optional id used when seeding messages into the chat.
+ * @property type Which side of the conversation the message belongs to.
+ * @property content Text shown to the user in the chat transcript.
+ * @property rawContent Raw value preserved for follow-up logic such as validation.
+ * @property timestamp Optional timestamp to use instead of the current time.
+ * @property isLoading Marks the message as a loading placeholder.
+ * @property loadingLabel Optional label announced while a loading message is shown.
+ * @property userResponseCallback Runs when the next user response should be handled by this message.
+ * @property buttons Optional actions shown below the message bubble.
  */
 export interface InputMessage {
   readonly id?: number;
@@ -71,10 +76,18 @@ export interface InputMessage {
   readonly rawContent?: string;
   readonly timestamp?: Date;
   readonly isLoading?: boolean;
+  readonly loadingLabel?: string;
   readonly userResponseCallback?: () => void;
   readonly buttons?: readonly MessageButton[];
 }
 
+/**
+ * Normalized message shape stored in chat state after defaults are applied.
+ *
+ * @property rawContent Raw value preserved for follow-up logic such as validation.
+ * @property timestamp Creation time assigned to the stored message.
+ * @property id Stable id assigned by the chat store.
+ */
 export interface Message
   extends Omit<InputMessage, 'rawContent' | 'timestamp' | 'id'> {
   readonly rawContent: string;
@@ -84,19 +97,21 @@ export interface Message
 
 /**
  * Props for the Chat component.
+ *
+ * @property initialMessages Optional messages shown when the chat first renders.
+ * @property theme Optional theme configuration for the chat UI.
  */
 export interface ChatProps {
-  /** Optional messages shown when the chat first renders. */
   readonly initialMessages?: readonly InputMessage[];
-  /** Optional theme configuration for the chat UI. */
   readonly theme?: ChatTheme;
 }
 
 /**
  * Props for the Chat component with flexible theme input.
  * Allows theme to be a string ('light' | 'dark'), a ChatTheme object, or undefined.
+ *
+ * @property theme Optional preset or full theme object used to style the chat UI.
  */
 export type ChatPropsWithFlexibleTheme = Omit<ChatProps, 'theme'> & {
-  /** Optional preset or full theme object used to style the chat UI. */
   readonly theme?: 'light' | 'dark' | ChatTheme | undefined;
 };

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -85,12 +85,11 @@ export interface Message
 
 /**
  * Props for the Chat component.
- *
- * @property initialMessages Optional array of messages to initialize the chat with.
- * @property theme Optional theme configuration to customize the chat appearance.
  */
 export interface ChatProps {
+  /** Optional messages shown when the chat first renders. */
   readonly initialMessages?: readonly InputMessage[];
+  /** Optional theme configuration for the chat UI. */
   readonly theme?: ChatTheme;
 }
 
@@ -99,5 +98,6 @@ export interface ChatProps {
  * Allows theme to be a string ('light' | 'dark'), a ChatTheme object, or undefined.
  */
 export type ChatPropsWithFlexibleTheme = Omit<ChatProps, 'theme'> & {
+  /** Optional preset or full theme object used to style the chat UI. */
   readonly theme?: 'light' | 'dark' | ChatTheme | undefined;
 };

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -71,7 +71,6 @@ export interface InputMessage {
   readonly rawContent?: string;
   readonly timestamp?: Date;
   readonly isLoading?: boolean;
-  readonly loadingLabel?: string;
   readonly userResponseCallback?: () => void;
   readonly buttons?: readonly MessageButton[];
 }

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -3,19 +3,23 @@
  * This file contains the store, used for interacting and managing the chat.
  */
 
-import { create } from 'zustand';
-import type { InputMessage, Message } from '../js/types';
-import { usePersistentButtonStore } from './persistentButtonStore';
+import { create } from "zustand";
+import type { InputMessage, Message } from "../js/types";
+import { usePersistentButtonStore } from "./persistentButtonStore";
 
-const ABORT_BUTTON_ID = 'input-request-abort';
+const ABORT_BUTTON_ID = "input-request-abort";
 
 interface ChatState {
   readonly messages: readonly Message[];
+  readonly isLoading: boolean;
+  readonly loadingMessage?: string | undefined;
   readonly getMessages: () => readonly Message[];
   readonly getPreviousMessage: () => Message | undefined;
   readonly addMessage: (message: InputMessage) => void;
   readonly addMessages: (messages: readonly InputMessage[]) => void;
   readonly setMessages: (messages: readonly Message[]) => void;
+  readonly setLoading: (isLoading: boolean, message?: string) => void;
+  readonly clearLoading: () => void;
   readonly clearMessages: () => void;
   readonly clearButtons: () => void;
   readonly clearPreviousMessageButtons: () => void;
@@ -24,6 +28,8 @@ interface ChatState {
 
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
+  isLoading: false,
+  loadingMessage: undefined,
 
   getMessages: () => {
     return get().messages;
@@ -34,7 +40,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     return messages.length > 0 ? messages[messages.length - 1] : undefined;
   },
 
-  addMessage: messageData => {
+  addMessage: (messageData) => {
     const currentMessages = get().messages;
     const newMessage: Message = {
       id: currentMessages.length + 1,
@@ -47,25 +53,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { removeButton } = usePersistentButtonStore.getState();
     removeButton(ABORT_BUTTON_ID);
 
-    set(state => ({
+    set((state) => ({
       // Clear buttons from all previous messages before adding the new one
       messages: [
-        ...state.messages.map(message => ({ ...message, buttons: [] })),
+        ...state.messages.map((message) => ({ ...message, buttons: [] })),
         newMessage,
       ],
     }));
   },
 
-  addMessages: messages => {
-    set(state => {
+  addMessages: (messages) => {
+    set((state) => {
       const currentMessages = state.messages;
       let nextId = currentMessages.length + 1;
       const now = new Date();
-      const newMessages: Message[] = messages.map(messageData => {
+      const newMessages: Message[] = messages.map((messageData) => {
         const msg: Message = {
           id: nextId++,
           timestamp: now,
-          rawContent: messageData.rawContent ?? messageData.content ?? '',
+          rawContent: messageData.rawContent ?? messageData.content ?? "",
           ...messageData,
         };
         return msg;
@@ -76,17 +82,37 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   },
 
-  setMessages: newMessages => {
+  setMessages: (newMessages) => {
     set({ messages: newMessages });
   },
 
+  setLoading: (isLoading, message) => {
+    set({
+      isLoading,
+      ...(isLoading
+        ? { loadingMessage: message }
+        : { loadingMessage: undefined }),
+    });
+  },
+
+  clearLoading: () => {
+    set({
+      isLoading: false,
+      loadingMessage: undefined,
+    });
+  },
+
   clearMessages: () => {
-    set({ messages: [] });
+    set({
+      messages: [],
+      isLoading: false,
+      loadingMessage: undefined,
+    });
   },
 
   clearButtons: () => {
-    set(state => ({
-      messages: state.messages.map(message => ({
+    set((state) => ({
+      messages: state.messages.map((message) => ({
         ...message,
         buttons: [],
       })),
@@ -96,11 +122,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
   clearPreviousMessageButtons: () => {
     const previousMessage = get().getPreviousMessage();
     if (previousMessage) {
-      set(state => ({
-        messages: state.messages.map(message =>
+      set((state) => ({
+        messages: state.messages.map((message) =>
           message.id === previousMessage.id
             ? { ...message, buttons: [] }
-            : message
+            : message,
         ),
       }));
     }
@@ -109,8 +135,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   clearPreviousMessageCallback: () => {
     const previousMessage = get().getPreviousMessage();
     if (previousMessage) {
-      set(state => ({
-        messages: state.messages.map(message => {
+      set((state) => ({
+        messages: state.messages.map((message) => {
           if (message.id === previousMessage.id) {
             const { userResponseCallback: _userResponseCallback, ...rest } =
               message;

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -9,6 +9,23 @@ import { usePersistentButtonStore } from './persistentButtonStore';
 
 const ABORT_BUTTON_ID = 'input-request-abort';
 
+/**
+ * Internal chat store shape.
+ *
+ * @property messages Current chat transcript.
+ * @property isLoading Whether the chat is currently waiting on async work.
+ * @property getMessages Returns the current chat transcript.
+ * @property getPreviousMessage Returns the latest message in the transcript.
+ * @property addMessage Adds one message to the transcript.
+ * @property addMessages Adds multiple messages to the transcript.
+ * @property setMessages Replaces the transcript with a new message list.
+ * @property setLoading Sets the loading state.
+ * @property clearLoading Clears the loading state.
+ * @property clearMessages Clears the transcript and loading state.
+ * @property clearButtons Removes buttons from all messages.
+ * @property clearPreviousMessageButtons Removes buttons from the latest message.
+ * @property clearPreviousMessageCallback Removes the latest message callback.
+ */
 interface ChatState {
   readonly messages: readonly Message[];
   readonly isLoading: boolean;
@@ -25,6 +42,9 @@ interface ChatState {
   readonly clearPreviousMessageCallback: () => void;
 }
 
+/**
+ * Shared chat state store for messages and loading state.
+ */
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   isLoading: false,

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -12,13 +12,12 @@ const ABORT_BUTTON_ID = 'input-request-abort';
 interface ChatState {
   readonly messages: readonly Message[];
   readonly isLoading: boolean;
-  readonly loadingMessage?: string | undefined;
   readonly getMessages: () => readonly Message[];
   readonly getPreviousMessage: () => Message | undefined;
   readonly addMessage: (message: InputMessage) => void;
   readonly addMessages: (messages: readonly InputMessage[]) => void;
   readonly setMessages: (messages: readonly Message[]) => void;
-  readonly setLoading: (isLoading: boolean, message?: string) => void;
+  readonly setLoading: (isLoading: boolean) => void;
   readonly clearLoading: () => void;
   readonly clearMessages: () => void;
   readonly clearButtons: () => void;
@@ -29,7 +28,6 @@ interface ChatState {
 export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   isLoading: false,
-  loadingMessage: undefined,
 
   getMessages: () => {
     return get().messages;
@@ -86,19 +84,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ messages: newMessages });
   },
 
-  setLoading: (isLoading, message) => {
+  setLoading: isLoading => {
     set({
       isLoading,
-      ...(isLoading
-        ? { loadingMessage: message }
-        : { loadingMessage: undefined }),
     });
   },
 
   clearLoading: () => {
     set({
       isLoading: false,
-      loadingMessage: undefined,
     });
   },
 
@@ -106,7 +100,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({
       messages: [],
       isLoading: false,
-      loadingMessage: undefined,
     });
   },
 

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -3,11 +3,11 @@
  * This file contains the store, used for interacting and managing the chat.
  */
 
-import { create } from "zustand";
-import type { InputMessage, Message } from "../js/types";
-import { usePersistentButtonStore } from "./persistentButtonStore";
+import { create } from 'zustand';
+import type { InputMessage, Message } from '../js/types';
+import { usePersistentButtonStore } from './persistentButtonStore';
 
-const ABORT_BUTTON_ID = "input-request-abort";
+const ABORT_BUTTON_ID = 'input-request-abort';
 
 interface ChatState {
   readonly messages: readonly Message[];
@@ -40,7 +40,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     return messages.length > 0 ? messages[messages.length - 1] : undefined;
   },
 
-  addMessage: (messageData) => {
+  addMessage: messageData => {
     const currentMessages = get().messages;
     const newMessage: Message = {
       id: currentMessages.length + 1,
@@ -53,25 +53,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { removeButton } = usePersistentButtonStore.getState();
     removeButton(ABORT_BUTTON_ID);
 
-    set((state) => ({
+    set(state => ({
       // Clear buttons from all previous messages before adding the new one
       messages: [
-        ...state.messages.map((message) => ({ ...message, buttons: [] })),
+        ...state.messages.map(message => ({ ...message, buttons: [] })),
         newMessage,
       ],
     }));
   },
 
-  addMessages: (messages) => {
-    set((state) => {
+  addMessages: messages => {
+    set(state => {
       const currentMessages = state.messages;
       let nextId = currentMessages.length + 1;
       const now = new Date();
-      const newMessages: Message[] = messages.map((messageData) => {
+      const newMessages: Message[] = messages.map(messageData => {
         const msg: Message = {
           id: nextId++,
           timestamp: now,
-          rawContent: messageData.rawContent ?? messageData.content ?? "",
+          rawContent: messageData.rawContent ?? messageData.content ?? '',
           ...messageData,
         };
         return msg;
@@ -82,7 +82,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   },
 
-  setMessages: (newMessages) => {
+  setMessages: newMessages => {
     set({ messages: newMessages });
   },
 
@@ -111,8 +111,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   clearButtons: () => {
-    set((state) => ({
-      messages: state.messages.map((message) => ({
+    set(state => ({
+      messages: state.messages.map(message => ({
         ...message,
         buttons: [],
       })),
@@ -122,11 +122,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
   clearPreviousMessageButtons: () => {
     const previousMessage = get().getPreviousMessage();
     if (previousMessage) {
-      set((state) => ({
-        messages: state.messages.map((message) =>
+      set(state => ({
+        messages: state.messages.map(message =>
           message.id === previousMessage.id
             ? { ...message, buttons: [] }
-            : message,
+            : message
         ),
       }));
     }
@@ -135,8 +135,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   clearPreviousMessageCallback: () => {
     const previousMessage = get().getPreviousMessage();
     if (previousMessage) {
-      set((state) => ({
-        messages: state.messages.map((message) => {
+      set(state => ({
+        messages: state.messages.map(message => {
           if (message.id === previousMessage.id) {
             const { userResponseCallback: _userResponseCallback, ...rest } =
               message;

--- a/src/lib/inputFieldStore.ts
+++ b/src/lib/inputFieldStore.ts
@@ -5,6 +5,9 @@
 
 import { create } from 'zustand';
 
+/**
+ * Supported HTML input types for the shared chat input field.
+ */
 export type InputType =
   | 'text'
   | 'password'
@@ -14,9 +17,50 @@ export type InputType =
   | 'url'
   | 'search';
 
+/**
+ * Result returned by an input validator.
+ */
 export type InputValidationResult = boolean | string;
+
+/**
+ * Validates a submitted input value before it is accepted.
+ *
+ * @param value The submitted input value to validate.
+ * @returns `true` when the value is valid, or an error message when it is not.
+ */
 export type InputValidator = (value: string) => InputValidationResult;
 
+/**
+ * Internal input field store shape.
+ *
+ * @property inputFieldElement Registered input element instance.
+ * @property inputFieldValue Current input field value.
+ * @property inputFieldSubmitFunc Registered submit callback for the input field.
+ * @property inputFieldDescription Helper text shown above the input field.
+ * @property inputFieldType Current HTML input type.
+ * @property inputFieldPlaceholder Current placeholder text.
+ * @property inputFieldValidator Current validator applied to submitted input.
+ * @property getInputFieldElement Returns the registered input element instance.
+ * @property getInputFieldValue Returns the current input field value.
+ * @property getInputFieldSubmitFunc Returns the registered submit callback.
+ * @property getInputFieldDescription Returns the helper text shown above the input field.
+ * @property getInputFieldType Returns the current HTML input type.
+ * @property getInputFieldPlaceholder Returns the current placeholder text.
+ * @property getInputFieldValidator Returns the current validator.
+ * @property setInputFieldElement Registers the input element instance.
+ * @property setInputFieldValue Updates the current input field value.
+ * @property setInputFieldSubmitFunc Registers the submit callback.
+ * @property setInputFieldDescription Updates the helper text shown above the input field.
+ * @property setInputFieldType Updates the current HTML input type.
+ * @property setInputFieldPlaceholder Updates the current placeholder text.
+ * @property setInputFieldValidator Updates the current validator.
+ * @property resetInputField Clears the registered element and submit callback.
+ * @property resetInputFieldValue Clears the current input field value.
+ * @property resetInputFieldDescription Clears the helper text.
+ * @property resetInputFieldType Resets the input type to `text`.
+ * @property resetInputFieldPlaceholder Resets the placeholder text.
+ * @property resetInputFieldValidator Clears the validator.
+ */
 interface InputFieldState {
   readonly inputFieldElement: HTMLInputElement | null;
   readonly inputFieldValue: string;
@@ -26,7 +70,6 @@ interface InputFieldState {
   readonly inputFieldPlaceholder: string;
   readonly inputFieldValidator: InputValidator | null;
 
-  // Getters
   readonly getInputFieldElement: () => HTMLInputElement | null;
   readonly getInputFieldValue: () => string;
   readonly getInputFieldSubmitFunc: () => (() => void) | null;
@@ -35,7 +78,6 @@ interface InputFieldState {
   readonly getInputFieldPlaceholder: () => string;
   readonly getInputFieldValidator: () => InputValidator | null;
 
-  // Setters
   readonly setInputFieldElement: (element: HTMLInputElement | null) => void;
   readonly setInputFieldValue: (value: string) => void;
   readonly setInputFieldSubmitFunc: (submitFunc: (() => void) | null) => void;
@@ -44,7 +86,6 @@ interface InputFieldState {
   readonly setInputFieldPlaceholder: (placeholder: string) => void;
   readonly setInputFieldValidator: (validator: InputValidator | null) => void;
 
-  // Resetters
   readonly resetInputField: () => void;
   readonly resetInputFieldValue: () => void;
   readonly resetInputFieldDescription: () => void;
@@ -53,6 +94,9 @@ interface InputFieldState {
   readonly resetInputFieldValidator: () => void;
 }
 
+/**
+ * Shared input field state store used by input-request flows.
+ */
 export const useInputFieldStore = create<InputFieldState>((set, get) => ({
   inputFieldElement: null,
   inputFieldValue: '',

--- a/src/lib/persistentButtonStore.ts
+++ b/src/lib/persistentButtonStore.ts
@@ -9,44 +9,37 @@ import type { MessageButton } from '../js/types';
 /**
  * A persistent button that extends MessageButton with a unique identifier.
  * These buttons are displayed at the bottom of the chat, above the input box.
+ *
+ * @property id Unique identifier for the persistent button.
  */
 interface PersistentButton extends MessageButton {
   readonly id: string;
 }
 
+/**
+ * Internal persistent button store shape.
+ *
+ * @property buttons Current persistent buttons shown above the input field.
+ * @property getButtons Returns the current array of persistent buttons.
+ * @property addButton Adds a new persistent button or updates an existing one with the same id.
+ * @property removeButton Removes a persistent button by id.
+ * @property setButtons Replaces all persistent buttons with a new array.
+ * @property clearButtons Removes all persistent buttons.
+ */
 interface PersistentButtonStoreState {
   readonly buttons: readonly PersistentButton[];
-
-  // Getters
-  /**
-   * Returns the current array of persistent buttons.
-   */
   readonly getButtons: () => readonly PersistentButton[];
-
-  // Setters
-  /**
-   * Adds a new persistent button or updates an existing one if a button with the same id already exists.
-   * @param button The button configuration with a unique id
-   */
   readonly addButton: (button: MessageButton & { readonly id: string }) => void;
-  /**
-   * Removes a persistent button by its id.
-   * @param id The unique identifier of the button to remove
-   */
   readonly removeButton: (id: string) => void;
-  /**
-   * Replaces all persistent buttons with the provided array.
-   * @param buttons Array of button configurations with unique ids
-   */
   readonly setButtons: (
     buttons: readonly (MessageButton & { readonly id: string })[]
   ) => void;
-  /**
-   * Removes all persistent buttons.
-   */
   readonly clearButtons: () => void;
 }
 
+/**
+ * Shared store for buttons that stay visible above the input field.
+ */
 export const usePersistentButtonStore = create<PersistentButtonStoreState>(
   (set, get) => ({
     buttons: [],

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,6 +1,8 @@
 import type { ChatTheme } from '../js/types';
 
-// Preset light and dark themes
+/**
+ * Built-in light theme preset for the chat UI.
+ */
 export const LIGHT_THEME: ChatTheme = {
   primaryColor: '#3b82f6', // Blue for self messages
   secondaryColor: '#e5e7eb', // Light gray for other messages
@@ -13,6 +15,9 @@ export const LIGHT_THEME: ChatTheme = {
   buttonTextColor: '#ffffff', // White button text
 };
 
+/**
+ * Built-in dark theme preset for the chat UI.
+ */
 export const DARK_THEME: ChatTheme = {
   primaryColor: '#4a7fc1', // Self message background (medium blue)
   secondaryColor: '#1a2942', // Other message background (dark blue-gray)
@@ -25,6 +30,9 @@ export const DARK_THEME: ChatTheme = {
   buttonTextColor: '#ffffff', // Button text (white)
 };
 
+/**
+ * Accepted theme inputs for the chat component and helpers.
+ */
 export type ThemeInput = 'light' | 'dark' | ChatTheme | undefined;
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,9 @@ import type { ClassValue } from 'clsx';
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Merges conditional class names and resolves Tailwind conflicts.
+ */
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,6 +318,10 @@
     visibility: visible;
   }
 
+  .static {
+    position: static;
+  }
+
   .container {
     width: 100%;
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,10 @@
     --text-xs--line-height: calc(1 / .75);
     --text-sm: .875rem;
     --text-sm--line-height: calc(1.25 / .875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
     --font-weight-medium: 500;
+    --font-weight-semibold: 600;
     --leading-relaxed: 1.625;
     --radius-lg: .5rem;
     --ease-out: cubic-bezier(0, 0, .2, 1);
@@ -311,6 +314,10 @@
 @layer components;
 
 @layer utilities {
+  .visible {
+    visibility: visible;
+  }
+
   .container {
     width: 100%;
   }
@@ -381,6 +388,10 @@
     display: flex;
   }
 
+  .hidden {
+    display: none;
+  }
+
   .inline {
     display: inline;
   }
@@ -423,6 +434,10 @@
 
   .max-w-\[85\%\] {
     max-width: 85%;
+  }
+
+  .min-w-\[1\.8rem\] {
+    min-width: 1.8rem;
   }
 
   .flex-1 {
@@ -473,6 +488,12 @@
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  .truncate {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   .overflow-y-auto {
@@ -559,6 +580,15 @@
     padding-block: calc(var(--spacing) * 3);
   }
 
+  .font-mono {
+    font-family: var(--font-mono);
+  }
+
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+  }
+
   .text-sm {
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
@@ -577,6 +607,11 @@
   .font-medium {
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
+  }
+
+  .font-semibold {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
   }
 
   .whitespace-nowrap {

--- a/src/styles.css
+++ b/src/styles.css
@@ -490,12 +490,6 @@
     margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
   }
 
-  .truncate {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
   .overflow-y-auto {
     overflow-y: auto;
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -318,10 +318,6 @@
     visibility: visible;
   }
 
-  .static {
-    position: static;
-  }
-
   .container {
     width: 100%;
   }


### PR DESCRIPTION
## Summary

- Adds reusable button definition helpers that separate static button definitions from runtime callbacks.
- Adds loading-state support in the chat store and UI, including a dedicated loading indicator component.
- Covers the new core behavior with focused tests.

## Why

The follow-on recommended-actions work needs a reusable way to define buttons once and attach runtime behavior later. It also needs first-class loading states while async recommendation work is in progress.

## Stack

- Position: `1/4`
- Base: `master`
- Follow-up: #91

## Validation

- `npm test -- --run`
- `npm run build`
- `cd examples/settings && npm run build`
