### PR TITLE
feat(ci): add PR failure guidance comments and improve GitHub workflows

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -11,6 +11,7 @@ GitHub Actions workflow definitions for continuous integration, releases, docs d
 - `ci.yml`: GitHub Actions workflow for the main CI checks, including AGENTS hierarchy validation.
 - `deploy-docs.yml`: GitHub Actions workflow that builds and deploys the docs site.
 - `e2e.yml`: GitHub Actions workflow that builds the example apps and runs the Playwright suite.
+- `pr-ci-failure-guidance.yml`: GitHub Actions workflow that comments on pull requests with recommended local commands for failed CI jobs.
 - `pr-coverage.yml`: GitHub Actions workflow that posts coverage summaries on pull requests.
 - `release.yml`: GitHub Actions workflow that publishes package releases.
 - `require-changeset.yml`: GitHub Actions workflow that enforces changeset coverage on pull requests.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -8,12 +8,12 @@ GitHub Actions workflow definitions for continuous integration, releases, docs d
 
 ## Files
 
-- `ci.yml`: GitHub Actions workflow for the main CI checks, including AGENTS hierarchy validation.
-- `deploy-docs.yml`: GitHub Actions workflow that builds and deploys the docs site.
+- `ci.yml`: GitHub Actions workflow for the main CI checks on pushes and pull requests across all branches, including AGENTS hierarchy validation.
+- `deploy-docs.yml`: GitHub Actions workflow that manually or reusably builds and deploys the docs site from the default branch.
 - `e2e.yml`: GitHub Actions workflow that builds the example apps and runs the Playwright suite.
 - `pr-ci-failure-guidance.yml`: GitHub Actions workflow that comments on pull requests with recommended local commands for failed CI jobs.
 - `pr-coverage.yml`: GitHub Actions workflow that posts coverage summaries on pull requests.
-- `release.yml`: GitHub Actions workflow that publishes package releases.
+- `release.yml`: GitHub Actions workflow that manually orchestrates docs deployment and package release steps.
 - `require-changeset.yml`: GitHub Actions workflow that enforces changeset coverage on pull requests.
 - `upload-coverage.yml`: GitHub Actions workflow that uploads coverage reports to Codecov.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches:
+      - '**'
   pull_request:
-    branches: [main, develop]
 
 jobs:
   format-check:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,7 @@
-name: Deploy Pages
+name: Deploy Docs
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -20,6 +19,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure workflow runs on the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            echo "Documentation deploys must run from $DEFAULT_BRANCH, got $REF_NAME."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -54,7 +63,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
-    name: Deploy Pages
+    name: Deploy Docs
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/pr-ci-failure-guidance.yml
+++ b/.github/workflows/pr-ci-failure-guidance.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main, develop]
 
 jobs:
   comment:

--- a/.github/workflows/pr-ci-failure-guidance.yml
+++ b/.github/workflows/pr-ci-failure-guidance.yml
@@ -1,0 +1,244 @@
+name: PR CI Failure Guidance
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main, develop]
+
+jobs:
+  comment:
+    name: Comment Failure Guidance
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Create or clear CI guidance comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-ci-failure-guidance -->';
+            const workflowRun = context.payload.workflow_run;
+            const pullRequest = workflowRun.pull_requests?.[0];
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const failureConclusions = new Set([
+              'action_required',
+              'failure',
+              'startup_failure',
+              'timed_out',
+            ]);
+
+            if (!pullRequest) {
+              core.notice('No pull request is associated with this workflow run.');
+              return;
+            }
+
+            const issue_number = pullRequest.number;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              }
+            );
+            const existingComment = comments.find(
+              comment =>
+                comment.user?.type === 'Bot' &&
+                comment.body?.includes(marker)
+            );
+
+            if (!failureConclusions.has(workflowRun.conclusion ?? '')) {
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                });
+                core.notice('Removed the stale CI failure guidance comment.');
+              } else {
+                core.notice('Latest CI run did not fail; no guidance comment needed.');
+              }
+              return;
+            }
+
+            const adviceByJobName = {
+              'Format Check': {
+                summary: 'Run Prettier and commit the formatted files.',
+                commands: ['pnpm format'],
+              },
+              'AGENTS Check': {
+                summary:
+                  'Refresh the AGENTS inventory, then commit the updated `AGENTS.md` files.',
+                commands: ['pnpm exec agentsmd-hierarchy fix .', 'pnpm agents:check'],
+              },
+              'Styles Sync Check': {
+                summary:
+                  'Regenerate the published stylesheet and commit the updated `src/styles.css`.',
+                commands: ['pnpm build:styles'],
+              },
+              'Docs Assistant Corpus Check': {
+                summary:
+                  'Regenerate the docs assistant corpus and commit the generated JSON artifact.',
+                commands: ['pnpm docs:assistant:corpus'],
+              },
+              'Linter Check': {
+                summary: 'Run ESLint locally and address the reported diagnostics.',
+                commands: ['pnpm lint'],
+              },
+              'Type Check': {
+                summary:
+                  'Rerun typechecking locally; this also validates docs snippets and reference pages.',
+                commands: ['pnpm typecheck'],
+              },
+              'Knip Check': {
+                summary:
+                  'Run Knip locally and remove or wire up the unused files, exports, or dependencies it reports.',
+                commands: ['pnpm knip'],
+              },
+              Build: {
+                summary:
+                  'Reproduce the build locally and fix the first build error before rerunning CI.',
+                commands: ['pnpm build'],
+              },
+              Test: {
+                summary:
+                  'Run the Vitest suite locally and fix the failing test or implementation.',
+                commands: ['pnpm test -- --run'],
+              },
+              E2E: {
+                summary:
+                  'Run the PR Playwright suite locally and inspect the first failing scenario.',
+                commands: ['pnpm test:e2e'],
+              },
+              Coverage: {
+                summary:
+                  'Reproduce the coverage run locally and fix the failing test or instrumentation issue.',
+                commands: ['pnpm test:coverage'],
+              },
+            };
+
+            const adviceByStepName = {
+              'Install dependencies': {
+                summary:
+                  'Reinstall workspace dependencies locally. If `pnpm-lock.yaml` changes, commit the updated lockfile.',
+                commands: ['pnpm install'],
+              },
+              'Install Playwright browsers': {
+                summary:
+                  'Install the required Playwright browser binaries locally before rerunning E2E.',
+                commands: ['pnpm exec playwright install --with-deps chromium'],
+              },
+              'Check formatting': adviceByJobName['Format Check'],
+              'Validate AGENTS.md hierarchy': adviceByJobName['AGENTS Check'],
+              'Check if styles.css is up to date': adviceByJobName['Styles Sync Check'],
+              'Check if docs assistant corpus is up to date':
+                adviceByJobName['Docs Assistant Corpus Check'],
+              'Run linter': adviceByJobName['Linter Check'],
+              'Type check': adviceByJobName['Type Check'],
+              'Check for unused files, exports, and dependencies':
+                adviceByJobName['Knip Check'],
+              Build: adviceByJobName.Build,
+              'Run tests': adviceByJobName.Test,
+              'Run E2E tests': adviceByJobName.E2E,
+              'Run coverage': adviceByJobName.Coverage,
+            };
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: workflowRun.id,
+                per_page: 100,
+              }
+            );
+            const failingJobs = jobs.filter(job =>
+              failureConclusions.has(job.conclusion ?? '')
+            );
+
+            if (failingJobs.length === 0) {
+              core.notice(
+                'Workflow concluded with a failure state, but no failed jobs were returned.'
+              );
+              return;
+            }
+
+            const commandSet = new Set();
+            const jobLines = failingJobs.map(job => {
+              const failedStep = job.steps?.find(step =>
+                failureConclusions.has(step.conclusion ?? '')
+              );
+              const advice =
+                adviceByStepName[failedStep?.name ?? ''] ??
+                adviceByJobName[job.name] ?? {
+                  summary:
+                    'Open the linked job log, rerun the matching command locally, and fix the first reported error.',
+                  commands: [],
+                };
+
+              for (const command of advice.commands) {
+                commandSet.add(command);
+              }
+
+              const stepLabel = failedStep?.name
+                ? ` failed at \`${failedStep.name}\``
+                : '';
+
+              return `- [\`${job.name}\`](${job.html_url})${stepLabel}: ${advice.summary}`;
+            });
+
+            const commandBlock = Array.from(commandSet)
+              .map(command => command)
+              .join('\n');
+
+            const bodyLines = [
+              marker,
+              'CI finished with failing checks for this PR.',
+              '',
+              ...jobLines,
+              '',
+            ];
+
+            if (commandBlock) {
+              bodyLines.push(
+                'Recommended local commands:',
+                '',
+                '```bash',
+                commandBlock,
+                '```',
+                ''
+              );
+            }
+
+            bodyLines.push(
+              `Workflow run: [\`${workflowRun.name ?? 'CI'} #${workflowRun.run_number}\`](${workflowRun.html_url})`
+            );
+
+            const body = bodyLines.join('\n');
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              core.notice('Updated the CI failure guidance comment.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+            core.notice('Created the CI failure guidance comment.');

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main, develop]
 
 jobs:
   coverage:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,64 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      deploy_docs:
+        description: 'Deploy the documentation site'
+        required: true
+        default: true
+        type: boolean
+      publish_packages:
+        description: 'Create or publish the package release via Changesets'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  pages: write
+  id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Release
+  validate-inputs:
+    name: Validate Release Inputs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure workflow runs on the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            echo "Release automation must run from $DEFAULT_BRANCH, got $REF_NAME."
+            exit 1
+          fi
+
+      - name: Ensure at least one target is selected
+        env:
+          DEPLOY_DOCS: ${{ inputs.deploy_docs }}
+          PUBLISH_PACKAGES: ${{ inputs.publish_packages }}
+        run: |
+          if [ "$DEPLOY_DOCS" != "true" ] && [ "$PUBLISH_PACKAGES" != "true" ]; then
+            echo 'Select at least one release target.'
+            exit 1
+          fi
+
+  deploy-docs:
+    name: Deploy Docs
+    needs: validate-inputs
+    if: ${{ inputs.deploy_docs }}
+    uses: ./.github/workflows/deploy-docs.yml
+    secrets: inherit
+
+  release-packages:
+    name: Release Packages
+    needs: validate-inputs
+    if: ${{ inputs.publish_packages }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,24 +84,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Check formatting
-        run: pnpm format:check
-
-      - name: Check if styles.css is up to date
-        run: pnpm check:styles
-
-      - name: Run linter
-        run: pnpm lint
-
-      - name: Type check
-        run: pnpm typecheck
-
-      - name: Check for unused files, exports, and dependencies
-        run: pnpm knip
-
-      - name: Build
-        run: pnpm build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION

This pull request updates and improves the GitHub Actions workflows for CI, documentation deployment, and release automation. The changes expand CI coverage, add a new workflow to provide actionable CI failure guidance on pull requests, and restructure documentation deployment and release workflows for better control and safety. Below are the most important changes grouped by theme:

**Continuous Integration and CI Failure Guidance:**
- CI now runs on all branches for both pushes and pull requests, ensuring comprehensive coverage across the repository. (`.github/workflows/ci.yml`, `.github/workflows/AGENTS.md`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-L7) [[2]](diffhunk://#diff-d1d469a15a3ae9d06d6d3d37a62541e5cb4b7f47ad7c7bd91392d3298487bd80L11-R16)
- Introduced a new `pr-ci-failure-guidance.yml` workflow that automatically comments on pull requests with specific local commands and troubleshooting steps when CI jobs fail, helping contributors quickly resolve issues. (`.github/workflows/pr-ci-failure-guidance.yml`, `.github/workflows/AGENTS.md`) [[1]](diffhunk://#diff-fad41fde72e76beb072f24b6944c507bb7d11fb95519beb0cbd6455d480d6820R1-R243) [[2]](diffhunk://#diff-d1d469a15a3ae9d06d6d3d37a62541e5cb4b7f47ad7c7bd91392d3298487bd80L11-R16)

**Documentation Deployment:**
- The documentation deployment workflow (`deploy-docs.yml`) can now be triggered manually or called from other workflows, and it enforces that deployments only occur from the repository's default branch. (`.github/workflows/deploy-docs.yml`, `.github/workflows/AGENTS.md`) [[1]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L1-R4) [[2]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R22-R31) [[3]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L57-R66) [[4]](diffhunk://#diff-d1d469a15a3ae9d06d6d3d37a62541e5cb4b7f47ad7c7bd91392d3298487bd80L11-R16)
- The `deploy-docs.yml` workflow is now reusable and renamed for clarity, aligning with the new release process. (`.github/workflows/deploy-docs.yml`, `.github/workflows/AGENTS.md`) [[1]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L1-R4) [[2]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L57-R66) [[3]](diffhunk://#diff-d1d469a15a3ae9d06d6d3d37a62541e5cb4b7f47ad7c7bd91392d3298487bd80L11-R16)

**Release Automation:**
- The `release.yml` workflow has been restructured to require manual input for deploying docs and/or publishing packages, and ensures these actions are only performed from the default branch. It now includes an input validation job and orchestrates docs deployment by calling the reusable `deploy-docs.yml`. (`.github/workflows/release.yml`, `.github/workflows/AGENTS.md`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L40-L57) [[3]](diffhunk://#diff-d1d469a15a3ae9d06d6d3d37a62541e5cb4b7f47ad7c7bd91392d3298487bd80L11-R16)
- Removed redundant pre-release checks from `release.yml` (such as formatting, linting, and type checking), delegating these responsibilities to the main CI workflow for a cleaner release process. (`.github/workflows/release.yml`)

**Other Workflow Updates:**
- Coverage and other reporting workflows have been updated to align with the expanded CI branch coverage. (`.github/workflows/pr-coverage.yml`)

These changes collectively make CI and release processes more robust, contributor-friendly, and maintainable.