### PR TITLE
Add embedded chat layout hooks

### DIFF
--- a/.changeset/chat-layout-props.md
+++ b/.changeset/chat-layout-props.md
@@ -1,0 +1,6 @@
+---
+'react-actions-chat': minor
+---
+
+- Add non-breaking Chat layout props for embedded panels.
+- Add stable Chat region attributes and CSS height variables.

--- a/docs/components/chat.md
+++ b/docs/components/chat.md
@@ -43,6 +43,29 @@ export function App() {
 
 By default, `Chat` keeps the shared input disabled until an input-request flow enables it. Set `allowFreeTextInput` when your assistant should accept open-ended typing at all times.
 
+## Embedded Layout
+
+`Chat` defaults to `layout='viewport'` so existing full-page demos keep the same viewport-height behavior. Use `layout='fill'` when the chat should fit an app panel that already controls its height.
+
+```tsx typecheck
+import { Chat } from 'react-actions-chat';
+
+export function SupportPanel() {
+  return (
+    <section style={{ height: 520, minHeight: 0 }}>
+      <Chat
+        layout='fill'
+        className='h-full min-h-0'
+        containerClassName='rounded-lg border'
+        contentClassName='px-5'
+      />
+    </section>
+  );
+}
+```
+
+The root wrapper exposes `data-asc-region='root'`, the themed container exposes `data-asc-region='container'`, the transcript keeps `data-asc-region='transcript'`, and the input area wrapper exposes `data-asc-region='input'`. You can also set `height`, `minHeight`, or the `--asc-chat-height` and `--asc-chat-min-height` CSS variables to tune sizing without reaching into child selectors.
+
 ## Conversation Model
 
 When the user submits text and/or files:

--- a/docs/guides/theming-and-styling.md
+++ b/docs/guides/theming-and-styling.md
@@ -51,6 +51,24 @@ export function App() {
 
 For the full `ChatTheme` shape and token list, see [`ChatTheme`](../types/chat-theme.md).
 
+## Layout Styling
+
+`Chat` preserves the legacy viewport-height layout by default. For embedded panels, pass `layout='fill'` and give the parent a definite height:
+
+```tsx typecheck
+import { Chat } from 'react-actions-chat';
+
+export function EmbeddedPanel() {
+  return (
+    <div style={{ height: 480, minHeight: 0 }}>
+      <Chat layout='fill' />
+    </div>
+  );
+}
+```
+
+The root wrapper accepts `className`, `style`, `height`, and `minHeight`. The themed container accepts `containerClassName`, and the transcript accepts `contentClassName`. For CSS-only sizing, set `--asc-chat-height` and `--asc-chat-min-height` on the root wrapper or an ancestor.
+
 ## Theme Helpers
 
 The library also exports:

--- a/docs/reference/core-api.md
+++ b/docs/reference/core-api.md
@@ -14,6 +14,15 @@ Props:
 - `allowFreeTextInput?: boolean`
 - `globals?: ChatGlobals`
 - `theme?: 'light' | 'dark' | ChatTheme`
+- `layout?: 'fill' | 'viewport'`
+- `className?: string`
+- `style?: ChatStyleProperties`
+- `containerClassName?: string`
+- `contentClassName?: string`
+- `height?: CSSProperties['height']`
+- `minHeight?: CSSProperties['minHeight']`
+
+`layout='viewport'` is the default for backward compatibility. Use `layout='fill'` for embedded panels where a parent element owns the height. The root wrapper also supports `--asc-chat-height` and `--asc-chat-min-height` through `style` or the `height` and `minHeight` props.
 
 ### `MessageList`
 

--- a/src/__tests__/Chat.test.tsx
+++ b/src/__tests__/Chat.test.tsx
@@ -92,6 +92,62 @@ describe('Chat Component Integration Tests', () => {
     expect(input).toHaveAttribute('placeholder', 'Input disabled.');
   });
 
+  it('should expose layout customization hooks without changing the default viewport layout', () => {
+    const { container } = render(
+      <Chat
+        className='custom-root'
+        containerClassName='custom-container'
+        contentClassName='custom-content'
+        height={520}
+        minHeight={240}
+      />
+    );
+    const root = container.querySelector<HTMLElement>(
+      '[data-asc-region="root"]'
+    );
+    const chatContainer = container.querySelector<HTMLElement>(
+      '[data-asc-region="container"]'
+    );
+    const transcript = container.querySelector<HTMLElement>(
+      '[data-asc-region="transcript"]'
+    );
+    const inputWrapper = container.querySelector<HTMLElement>(
+      '[data-asc-region="input"]'
+    );
+    const inputBar = container.querySelector<HTMLElement>(
+      '[data-asc-region="input-bar"]'
+    );
+
+    if (!root || !chatContainer || !transcript || !inputWrapper || !inputBar) {
+      throw new Error('Expected Chat layout regions to render.');
+    }
+
+    expect(root).toHaveClass('asc-chat-wrapper', 'custom-root');
+    expect(root.style.getPropertyValue('--asc-chat-height')).toBe('520px');
+    expect(root.style.getPropertyValue('--asc-chat-min-height')).toBe('240px');
+    expect(chatContainer).toHaveAttribute('data-asc-layout', 'viewport');
+    expect(chatContainer).toHaveClass('asc-chat-container', 'custom-container');
+    expect(chatContainer).not.toHaveClass('h-screen');
+    expect(transcript).toHaveClass('custom-content');
+    expect(inputWrapper).toHaveClass('shrink-0');
+    expect(inputBar).toHaveClass('shrink-0');
+  });
+
+  it('should support fill layout for embedded panels', () => {
+    const { container } = render(<Chat layout='fill' />);
+    const chatContainer = container.querySelector<HTMLElement>(
+      '[data-asc-region="container"]'
+    );
+
+    if (!chatContainer) {
+      throw new Error('Expected Chat container region to render.');
+    }
+
+    expect(chatContainer).toHaveAttribute('data-asc-layout', 'fill');
+    expect(chatContainer).toHaveClass('h-full', 'min-h-0');
+    expect(chatContainer).not.toHaveClass('h-screen');
+  });
+
   it('should render with initial messages', () => {
     const initialMessages: InputMessage[] = [
       createInputMessage('Hello!', {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import {
   createTextPart,
   type ChatPropsWithFlexibleTheme,
+  type ChatStyleProperties,
   type MessagePart,
 } from '../../js/types';
 import {
@@ -14,9 +15,25 @@ import {
 import { createMessagePartsFromFiles } from '../../lib/messageParts';
 import type { InputSubmission } from '../../lib/inputFieldStore';
 import { hasInputBlockingButtons } from '../../lib/messageButtons';
+import { cn } from '../../lib/utils';
 import { InputBar } from '../InputBar/InputBar';
 import { MessageList } from '../MessageList/MessageList';
 import { PersistentButtons } from './PersistentButtons';
+
+/**
+ * Converts React numeric length props into CSS-variable-safe pixel values.
+ *
+ * @param value - Length value supplied through the Chat sizing props.
+ */
+function toCssLengthVariableValue(
+  value: React.CSSProperties['height']
+): React.CSSProperties['height'] {
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+
+  return value;
+}
 
 /**
  * Renders the chat UI and wires user input into the shared chat state.
@@ -25,8 +42,15 @@ import { PersistentButtons } from './PersistentButtons';
  */
 export function Chat({
   allowFreeTextInput = false,
+  className,
+  containerClassName,
+  contentClassName,
   globals = {},
+  height,
   initialMessages = [],
+  layout = 'viewport',
+  minHeight,
+  style,
   theme,
 }: ChatPropsWithFlexibleTheme): React.JSX.Element {
   const {
@@ -46,6 +70,21 @@ export function Chat({
 
   const mergedTheme = getResolvedTheme(theme);
   const inputBlockedByVisibleButtons = hasInputBlockingButtons(messages);
+  const rootStyle: ChatStyleProperties = { ...style };
+  const rootClassName = cn('asc-chat-wrapper', className);
+  const chatContainerClassName = cn(
+    'asc-chat-container flex min-h-0 flex-col',
+    layout === 'fill' ? 'h-full' : undefined,
+    containerClassName
+  );
+
+  if (height !== undefined) {
+    rootStyle['--asc-chat-height'] = toCssLengthVariableValue(height);
+  }
+
+  if (minHeight !== undefined) {
+    rootStyle['--asc-chat-min-height'] = toCssLengthVariableValue(minHeight);
+  }
 
   useEffect(() => {
     const inputFieldStore = useInputFieldStore.getState();
@@ -131,9 +170,15 @@ export function Chat({
   };
 
   return (
-    <div className='asc-chat-wrapper'>
+    <div
+      className={rootClassName}
+      data-asc-region='root'
+      style={Object.keys(rootStyle).length > 0 ? rootStyle : undefined}
+    >
       <div
-        className='flex h-screen flex-col'
+        className={chatContainerClassName}
+        data-asc-layout={layout}
+        data-asc-region='container'
         style={{
           ...getThemeStyles(mergedTheme),
           backgroundColor: mergedTheme.backgroundColor,
@@ -144,13 +189,19 @@ export function Chat({
           messages={messages}
           isLoading={isLoading}
           theme={mergedTheme}
+          className={contentClassName}
         />
-        <PersistentButtons theme={mergedTheme} />
-        <InputBar
-          onSend={handleSend}
-          theme={mergedTheme}
-          isInputBlocked={inputBlockedByVisibleButtons}
-        />
+        <div
+          className='shrink-0'
+          data-asc-region='input'
+        >
+          <PersistentButtons theme={mergedTheme} />
+          <InputBar
+            onSend={handleSend}
+            theme={mergedTheme}
+            isInputBlocked={inputBlockedByVisibleButtons}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/Chat/PersistentButtons.tsx
+++ b/src/components/Chat/PersistentButtons.tsx
@@ -36,7 +36,7 @@ export function PersistentButtons({
 
   return (
     <div
-      className='flex flex-wrap justify-center gap-2 border-t px-4 py-3'
+      className='flex shrink-0 flex-wrap justify-center gap-2 border-t px-4 py-3'
       role='region'
       aria-label='Chat persistent actions'
       data-asc-region='persistent-actions'

--- a/src/components/InputBar/InputBar.tsx
+++ b/src/components/InputBar/InputBar.tsx
@@ -319,7 +319,8 @@ export function InputBar({
 
   return (
     <div
-      className='border-t p-4'
+      className='shrink-0 border-t p-4'
+      data-asc-region='input-bar'
       style={{
         borderColor: `${theme.borderColor}40`,
         backgroundColor: theme.backgroundColor,

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import type { ChatTheme, Message as ChatMessage } from '../../js/types';
+import { cn } from '../../lib/utils';
 import { Message } from '../Message/Message';
 import { renderPart } from './parts/renderPart';
 
@@ -9,6 +10,7 @@ import { renderPart } from './parts/renderPart';
  * @property messages Messages to render in the chat transcript.
  * @property isLoading Shows the loading indicator below the transcript when true.
  * @property theme Theme tokens used to style message surfaces.
+ * @property className Additional classes applied to the scrollable transcript region.
  */
 interface MessageListProps {
   /**
@@ -23,6 +25,10 @@ interface MessageListProps {
    * Theme tokens used to style the rendered UI.
    */
   readonly theme: ChatTheme;
+  /**
+   * Additional classes applied to the scrollable transcript region.
+   */
+  readonly className?: string | undefined;
 }
 
 /**
@@ -34,6 +40,7 @@ export function MessageList({
   messages,
   isLoading = false,
   theme,
+  className,
 }: MessageListProps): React.JSX.Element {
   const messageListRef = useRef<HTMLDivElement>(null);
   const hasAutoScrolledRef = useRef(false);
@@ -64,7 +71,10 @@ export function MessageList({
   return (
     <div
       ref={messageListRef}
-      className='flex-1 space-y-5 overflow-y-auto scroll-smooth p-6'
+      className={cn(
+        'min-h-0 flex-1 space-y-5 overflow-y-auto scroll-smooth p-6',
+        className
+      )}
       role='log'
       aria-label='Chat transcript'
       aria-live='polite'

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,20 @@ body {
   --asc-motion-ease-settle: cubic-bezier(0.33, 1, 0.68, 1);
 }
 
+.asc-chat-container {
+  min-width: 0;
+  min-height: var(--asc-chat-min-height, 0px);
+  height: var(--asc-chat-height, 100vh);
+}
+
+.asc-chat-container[data-asc-layout='fill'] {
+  height: var(--asc-chat-height, 100%);
+}
+
+.asc-chat-container[data-asc-layout='viewport'] {
+  height: var(--asc-chat-height, 100vh);
+}
+
 .asc-message {
   animation-duration: var(--asc-motion-duration-message);
   animation-fill-mode: both;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import {
 import type {
   ChatProps,
   ChatPropsWithFlexibleTheme,
+  ChatLayout,
+  ChatStyleProperties,
   ChatTheme,
   FileMessagePart,
   ImageMessagePart,
@@ -71,7 +73,9 @@ export type {
   ChatProps,
   ChatPropsWithFlexibleTheme,
   ChatGlobals,
+  ChatLayout,
   ChatTheme,
+  ChatStyleProperties,
   CreatedButton,
   InputBarBehaviorConfig,
   InputBarModeConfig,

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -442,12 +442,41 @@ export interface Message extends Omit<
 }
 
 /**
+ * Layout sizing mode used by the Chat component.
+ */
+export type ChatLayout = 'fill' | 'viewport';
+
+/**
+ * Inline styles accepted by the Chat root wrapper.
+ *
+ * @property --asc-chat-height CSS length used as the rendered chat height.
+ * @property --asc-chat-min-height CSS length used as the rendered chat minimum height.
+ */
+export interface ChatStyleProperties extends React.CSSProperties {
+  /**
+   * CSS custom property that controls the rendered chat height.
+   */
+  '--asc-chat-height'?: React.CSSProperties['height'];
+  /**
+   * CSS custom property that controls the rendered chat minimum height.
+   */
+  '--asc-chat-min-height'?: React.CSSProperties['minHeight'];
+}
+
+/**
  * Props for the Chat component.
  *
  * @property initialMessages Optional messages shown when the chat first renders.
  * @property allowFreeTextInput When true, keeps the shared input enabled outside input-request flows.
  * @property globals Optional Chat-level defaults applied to helper flows such as request-input buttons.
  * @property theme Optional theme configuration for the chat UI.
+ * @property layout Size behavior for the rendered chat container.
+ * @property className Additional classes applied to the root wrapper.
+ * @property style Inline styles and supported CSS variables applied to the root wrapper.
+ * @property containerClassName Additional classes applied to the themed chat container.
+ * @property contentClassName Additional classes applied to the scrollable transcript region.
+ * @property height Value assigned to `--asc-chat-height` on the root wrapper; numeric values are treated as pixels.
+ * @property minHeight Value assigned to `--asc-chat-min-height` on the root wrapper; numeric values are treated as pixels.
  */
 export interface ChatProps {
   /**
@@ -466,6 +495,34 @@ export interface ChatProps {
    * Theme tokens used to style the rendered UI.
    */
   readonly theme?: ChatTheme;
+  /**
+   * Size behavior for the rendered chat container.
+   */
+  readonly layout?: ChatLayout | undefined;
+  /**
+   * Additional classes applied to the root wrapper.
+   */
+  readonly className?: string | undefined;
+  /**
+   * Inline styles and supported CSS variables applied to the root wrapper.
+   */
+  readonly style?: ChatStyleProperties | undefined;
+  /**
+   * Additional classes applied to the themed chat container.
+   */
+  readonly containerClassName?: string | undefined;
+  /**
+   * Additional classes applied to the scrollable transcript region.
+   */
+  readonly contentClassName?: string | undefined;
+  /**
+   * Value assigned to `--asc-chat-height` on the root wrapper; numeric values are treated as pixels.
+   */
+  readonly height?: React.CSSProperties['height'] | undefined;
+  /**
+   * Value assigned to `--asc-chat-min-height` on the root wrapper; numeric values are treated as pixels.
+   */
+  readonly minHeight?: React.CSSProperties['minHeight'] | undefined;
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -455,8 +455,12 @@
     height: auto;
   }
 
-  .h-screen {
-    height: 100vh;
+  .h-full {
+    height: 100%;
+  }
+
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
   }
 
   .min-h-\[52px\] {
@@ -954,6 +958,20 @@ body {
   --asc-motion-duration-loading: 1.1s;
   --asc-motion-ease-enter: cubic-bezier(.22, 1, .36, 1);
   --asc-motion-ease-settle: cubic-bezier(.33, 1, .68, 1);
+}
+
+.asc-chat-container {
+  min-width: 0;
+  min-height: var(--asc-chat-min-height, 0px);
+  height: var(--asc-chat-height, 100vh);
+}
+
+.asc-chat-container[data-asc-layout="fill"] {
+  height: var(--asc-chat-height, 100%);
+}
+
+.asc-chat-container[data-asc-layout="viewport"] {
+  height: var(--asc-chat-height, 100vh);
 }
 
 .asc-message {


### PR DESCRIPTION
## Summary
- add non-breaking Chat layout props for embedded panels
- replace internal h-screen usage with CSS-variable-backed container sizing
- add stable chat region attributes and shrink the input wrapper explicitly

## Verification
- pnpm run build:styles
- pnpm exec vitest --config config/vite.config.ts src/__tests__/Chat.test.tsx --run
- pnpm run typecheck
- pnpm run lint
- git diff --check